### PR TITLE
Add ENS registry address flag

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -7,7 +7,7 @@ const cli = meow(`
     $ aragon-dev-cli <subcommand>
 
   Commands
-    init <name>                   Initialize a new Aragon module
+    init <name>                   Initialize a new Aragon module (e.g. test.aragonpm.eth)
     version <major|minor|patch>   Bump the module version
     versions                      List the published versions of this module
     publish                       Publish a new version of the module
@@ -15,7 +15,6 @@ const cli = meow(`
 
   Options
     --key <privkey>               The Ethereum private key to sign transactions with. Raw transaction will be dumped to stdout if no key is provided.
-    --apm-registry <registry>     The repository registry to use for creating and publishing packages (default: aragonpm.eth)
     --rpc                         A URI to the Ethereum node used for RPC calls (default: https://ropsten.infura.io)
     --chain-id                    The ID of the chain to interact with (default: 3)
     --ens-registry                Address for the ENS registry (default: canonical ENS for chainId)
@@ -24,18 +23,14 @@ const cli = meow(`
     $ aragon-dev-cli version major
     New version is 2.0.0
 
-    $ aragon-dev-cli init poll --registry=module-corp.eth
-    Created new module poll.module-corp.eth
-
-    $ aragon-dev-cli init cool-app
+    $ aragon-dev-cli init cool-app.aragonpm.eth
     Created new module cool-app.aragonpm.eth
 `, {
   default: {
-    registry: 'aragonpm.eth',
     rpc: 'https://ropsten.infura.io',
-    chainId: 3
+    chainId: 3,
   },
-  string: ['key', 'rpc', 'registry']
+  string: ['key', 'rpc', 'ens-registry']
 })
 
 handle(cli)

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,19 +5,20 @@ const handle = require('../src/handle')
 const cli = meow(`
   Usage
     $ aragon-dev-cli <subcommand>
-  
+
   Commands
     init <name>                   Initialize a new Aragon module
     version <major|minor|patch>   Bump the module version
     versions                      List the published versions of this module
     publish                       Publish a new version of the module
-    playground                    Inject module into local Aragon application    
-  
+    playground                    Inject module into local Aragon application
+
   Options
-    --key <privkey>               The Ethereum private key to sign transactions with. Raw transaction will be dumped to stdout if no key is provided.  
+    --key <privkey>               The Ethereum private key to sign transactions with. Raw transaction will be dumped to stdout if no key is provided.
     --registry <registry>         The repository registry to use for creating and publishing packages (default: aragonpm.eth)
     --rpc                         A URI to the Ethereum node used for RPC calls (default: https://ropsten.infura.io)
     --chain-id                    The ID of the chain to interact with (default: 3)
+    --ens                         Address for the ENS registry (default: canonical ENS for chainId)
 
   Examples
     $ aragon-dev-cli version major

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -15,10 +15,10 @@ const cli = meow(`
 
   Options
     --key <privkey>               The Ethereum private key to sign transactions with. Raw transaction will be dumped to stdout if no key is provided.
-    --registry <registry>         The repository registry to use for creating and publishing packages (default: aragonpm.eth)
+    --apm-registry <registry>     The repository registry to use for creating and publishing packages (default: aragonpm.eth)
     --rpc                         A URI to the Ethereum node used for RPC calls (default: https://ropsten.infura.io)
     --chain-id                    The ID of the chain to interact with (default: 3)
-    --ens                         Address for the ENS registry (default: canonical ENS for chainId)
+    --ens-registry                Address for the ENS registry (default: canonical ENS for chainId)
 
   Examples
     $ aragon-dev-cli version major

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aragon/aragon-dev-cli",
+  "name": "@aragon/cli",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/src/handle.js
+++ b/src/handle.js
@@ -26,12 +26,8 @@ const handlers = {
       reporter.fatal('No name specified')
     }
 
-    if (!flags.apm-registry) {
-      reporter.fatal('No registry specified')
-    }
-
     pkg.write({
-      appName: name + '.' + flags.apm-registry,
+      appName: name,
       version: '1.0.0',
       roles: [],
       path: 'src/App.sol'
@@ -44,7 +40,7 @@ const handlers = {
       .then(async ({ appName }) => {
         const eth = new Web3Eth(flags.rpc)
 
-        const ensAddress = flags.ens-registry || ens.chainRegistry(flags.chainId)
+        const ensAddress = flags.ensRegistry || ens.chainRegistry(flags.chainId)
         const repoAddress = await ens.resolve(appName, eth, ensAddress)
         if (repoAddress === consts.NULL_ADDRESS) {
           return []
@@ -201,7 +197,7 @@ const handlers = {
       .then(async ({ appName, version, hash }) => {
         const eth = new Web3Eth(flags.rpc)
 
-        const ensAddress = flags.ens-registry || ens.chainRegistry(flags.chainId)
+        const ensAddress = flags.ensRegistry || ens.chainRegistry(flags.chainId)
         let repoAddress = await ens.resolve(appName, eth, ensAddress)
         if (repoAddress === consts.NULL_ADDRESS) {
           // Create new repo

--- a/src/handle.js
+++ b/src/handle.js
@@ -26,12 +26,12 @@ const handlers = {
       reporter.fatal('No name specified')
     }
 
-    if (!flags.registry) {
+    if (!flags.apm-registry) {
       reporter.fatal('No registry specified')
     }
 
     pkg.write({
-      appName: name + '.' + flags.registry,
+      appName: name + '.' + flags.apm-registry,
       version: '1.0.0',
       roles: [],
       path: 'src/App.sol'
@@ -44,7 +44,7 @@ const handlers = {
       .then(async ({ appName }) => {
         const eth = new Web3Eth(flags.rpc)
 
-        const ensAddress = flags.ens || ens.chainRegistry(flags.chainId)
+        const ensAddress = flags.ens-registry || ens.chainRegistry(flags.chainId)
         const repoAddress = await ens.resolve(appName, eth, ensAddress)
         if (repoAddress === consts.NULL_ADDRESS) {
           return []
@@ -201,7 +201,7 @@ const handlers = {
       .then(async ({ appName, version, hash }) => {
         const eth = new Web3Eth(flags.rpc)
 
-        const ensAddress = flags.ens || ens.chainRegistry(flags.chainId)
+        const ensAddress = flags.ens-registry || ens.chainRegistry(flags.chainId)
         let repoAddress = await ens.resolve(appName, eth, ensAddress)
         if (repoAddress === consts.NULL_ADDRESS) {
           // Create new repo

--- a/src/handle.js
+++ b/src/handle.js
@@ -44,7 +44,8 @@ const handlers = {
       .then(async ({ appName }) => {
         const eth = new Web3Eth(flags.rpc)
 
-        const repoAddress = await ens.resolve(appName, eth, flags.chainId)
+        const ensAddress = flags.ens || ens.chainRegistry(flags.chainId)
+        const repoAddress = await ens.resolve(appName, eth, ensAddress)
         if (repoAddress === consts.NULL_ADDRESS) {
           return []
         }
@@ -200,11 +201,12 @@ const handlers = {
       .then(async ({ appName, version, hash }) => {
         const eth = new Web3Eth(flags.rpc)
 
-        let repoAddress = await ens.resolve(appName, eth, flags.chainId)
+        const ensAddress = flags.ens || ens.chainRegistry(flags.chainId)
+        let repoAddress = await ens.resolve(appName, eth, ensAddress)
         if (repoAddress === consts.NULL_ADDRESS) {
           // Create new repo
           const registryName = appName.split('.').splice(-2).join('.')
-          const registryAddress = await ens.resolve(registryName, eth, flags.chainId)
+          const registryAddress = await ens.resolve(registryName, eth, ensAddress)
           if (registryAddress === consts.NULL_ADDRESS) {
             reporter.error(`Registry ${registryName} does not exist.`)
             return

--- a/src/utils/ens-resolve.js
+++ b/src/utils/ens-resolve.js
@@ -3,22 +3,28 @@ const consts = require('./constants')
 
 const registries = {
   1: '0x314159265dd8dbb310642f98f50c066173c1259b',
-  3: '0x112234455c3a32fd11230c42e7bccd4a84e02010'
+  3: '0x112234455c3a32fd11230c42e7bccd4a84e02010',
 }
 
-module.exports.resolve = function (name, eth, chainId = 1) {
-  const node = hash(name)
+module.exports = {
+    chainRegistry(chainId) {
+        return registries[chainId]
+    },
 
-  return new eth.Contract(
-    require('../../abi/ens/ENSRegistry.json'),
-    registries[chainId]
-  ).methods.resolver(node).call()
-    .then((resolverAddress) =>
-      resolverAddress === consts.NULL_ADDRESS
-        ? resolverAddress
-        : new eth.Contract(
-          require('../../abi/ens/ENSResolver.json'),
-          resolverAddress
-        ).methods.addr(node).call()
-    )
+    resolve(name, eth, registryAddress = this.chainRegistry(1)) {
+        const node = hash(name)
+
+        return new eth.Contract(
+        require('../../abi/ens/ENSRegistry.json'),
+        registryAddress
+        ).methods.resolver(node).call()
+        .then((resolverAddress) =>
+          resolverAddress === consts.NULL_ADDRESS
+            ? resolverAddress
+            : new eth.Contract(
+              require('../../abi/ens/ENSResolver.json'),
+              resolverAddress
+            ).methods.addr(node).call()
+        )
+    },
 }


### PR DESCRIPTION
Adds support to passing a custom ENS Registry address as an option. This allows to use aragon-dev- cli in a dev network without a canonical ENS Registry