### PR TITLE
Support scaffolding

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -7,7 +7,7 @@ const cli = meow(`
     $ aragon-dev-cli <subcommand>
   
   Commands
-    init <name>                   Initialize a new Aragon module
+    init <name> [template]        Initialize a new Aragon module from a template (default template: react)
     version <major|minor|patch>   Bump the module version
     versions                      List the published versions of this module
     publish                       Publish a new version of the module

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aragon/aragon-dev-cli",
+  "name": "@aragon/cli",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -4204,6 +4204,11 @@
       "requires": {
         "assert-plus": "1.0.0"
       }
+    },
+    "git-clone": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/git-clone/-/git-clone-0.1.0.tgz",
+      "integrity": "sha1-DXYWN3gJOu9/HDAjjyqe8/B6Lrk="
     },
     "git-raw-commits": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "chalk": "^2.1.0",
     "decamelize": "^1.2.0",
     "eth-ens-namehash": "^2.0.0",
+    "git-clone": "^0.1.0",
     "ipfs-api": "^14.3.5",
     "meow": "^3.7.0",
     "npm-run": "^4.1.2",

--- a/src/handle.js
+++ b/src/handle.js
@@ -13,6 +13,7 @@ const namehash = require('eth-ens-namehash')
 const inspector = require('solidity-inspector')
 const config = require('./config')()
 const pkgDir = require('pkg-dir')
+const clone = require('git-clone')
 
 const prettyKey = (key) => {
   let str = decamelize(key, ' ')
@@ -21,7 +22,7 @@ const prettyKey = (key) => {
 }
 
 const handlers = {
-  init ([name], flags) {
+  init ([name, template], flags) {
     if (!name) {
       reporter.fatal('No name specified')
     }
@@ -30,13 +31,22 @@ const handlers = {
       reporter.fatal('No registry specified')
     }
 
-    pkg.write({
-      appName: name + '.' + flags.registry,
-      version: '1.0.0',
-      roles: [],
-      path: 'src/App.sol'
-    }).then(({ appName }) => {
-      reporter.info(`Created new module ${appName}`)
+    if (!template) {
+      template = 'react'
+    }
+
+    // Determine template repository name
+    const aliasedTemplates = {
+      bare: 'aragon/aragon-bare-boilerplate',
+      react: 'aragon/aragon-react-boilerplate'
+    }
+    if (aliasedTemplates[template]) template = aliasedTemplates[template]
+
+    // Clone the template into the directory
+    // TODO: Somehow write name to `manifest.json` in template?
+    const basename = name.split('.')[0]
+    clone(`https://github.com/${template}`, basename, { shallow: true }, () => {
+      reporter.info(`Created new module ${appName} in ${basename}`)
     })
   },
   versions (_, flags) {

--- a/src/handle.js
+++ b/src/handle.js
@@ -37,10 +37,12 @@ const handlers = {
       react: 'aragon/aragon-react-boilerplate'
     }
     if (aliasedTemplates[template]) template = aliasedTemplates[template]
+    
 
     // Clone the template into the directory
     // TODO: Somehow write name to `manifest.json` in template?
     const basename = name.split('.')[0]
+    reporter.info(`Cloning ${template} into ${basename}...`)
     clone(`https://github.com/${template}`, basename, { shallow: true }, () => {
       reporter.info(`Created new module ${name} in ${basename}`)
     })

--- a/src/handle.js
+++ b/src/handle.js
@@ -41,6 +41,7 @@ const handlers = {
 
     // Clone the template into the directory
     // TODO: Somehow write name to `manifest.json` in template?
+    // TODO: Write human-readable app name to `module.json`
     const basename = name.split('.')[0]
     reporter.info(`Cloning ${template} into ${basename}...`)
     clone(`https://github.com/${template}`, basename, { shallow: true }, () => {


### PR DESCRIPTION
Adds support for scaffolding in the `init` command (for example `aragon-dev-cli init [app ENS name] [template name, github repository name]`)

The command will clone a GitHub repository into a folder. It defaults to cloning aragon/aragon-react-boilerplate. The contents will be cloned to the "base name" of the application's ENS name, e.g. for foo.aragonpm.eth it would be cloned to a folder called foo.

Given we have multiple official boilerplates, we can alias them (for example, instead of typing `aragon/aragon-react-boilerplate`, simply typing `react` is good enough).

**Unsolved**
- We somehow need to update the `name` key of the `manifest.json` file in templates, but they might be in different locations

Closes #10 