### PR TITLE
Fix errors when running init in clean directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,7 @@
     "coveralls": "^3.0.0",
     "standard": "^10.0.3"
   },
-  "engines" : { "node" : ">=8.9.1" }
+  "engines": {
+    "node": ">=8.9.1"
+  }
 }

--- a/src/middleware/manifest.js
+++ b/src/middleware/manifest.js
@@ -7,11 +7,11 @@ module.exports = function manifestMiddleware (argv) {
   if (!runsInCwd) {
     try {
       const manifestPath = path.resolve(findProjectRoot(), 'manifest.json')
-      manifest = fs.readJsonSync(manifestPath)
+      const manifest = fs.readJsonSync(manifestPath)
 
       return { manifest }
     } catch (err) {
-      argv.reporter.debug(err)
+      argv.reporter && argv.reporter.debug(err)
     }
   }
 

--- a/src/middleware/module.js
+++ b/src/middleware/module.js
@@ -7,11 +7,11 @@ module.exports = function moduleMiddleware (argv) {
   if (!runsInCwd) {
     try {
       const modulePath = path.resolve(findProjectRoot(), 'module.json')
-      module = fs.readJsonSync(modulePath)
+      const module = fs.readJsonSync(modulePath)
 
       return { module }
     } catch (err) {
-      argv.reporter.debug(err)
+      argv.reporter && argv.reporter.debug(err)
     }
   }
 

--- a/test/apm/storage/fs.js
+++ b/test/apm/storage/fs.js
@@ -1,5 +1,5 @@
 const test = require('ava')
-const fsStorageProvider = require('../../../src/apm/storage/fs')
+const fsStorageProvider = require('../../../src/apm/storage/fs')()
 
 test('apm.storage.fs#getFile', (t) => {
   return fsStorageProvider.getFile('./test/fixtures/single-file', 'foo.txt')


### PR DESCRIPTION
I saw the repo at https://github.com/aragon/hack and tried to create a project in a clean directory and it failed. When I proceeded to debug I noticed the code in the npm registry is different from the master branch at aragon/aragon-dev-cli although the version is the same. So I cloned the project and tried to `init` but it failed again. After some digging around I found that since no `manifest.json` and no `module.json` files are found then the `init` command failed. I believe the intention there is to catch and show the error only in debug mode. When the error is caught it should be a no-op but since `argv.reporter` is undefined then the process throws on trying to call its `debug` method.

Hope this helps others get onboard in a more seamless manner. 