### PR TITLE
Rename bin from aragon-dev-cli to aragon

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Aragon command-line tools",
   "main": "src/cli.js",
   "bin": {
-    "aragon-dev-cli": "./src/cli.js"
+    "aragon": "./src/cli.js"
   },
   "scripts": {
     "test": "ava",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Aragon command-line tools",
   "main": "src/cli.js",
   "bin": {
-    "aragon": "./src/cli.js"
+    "aragon": "./src/cli.js",
+    "aragon-dev-cli": "./src/cli.js"
   },
   "scripts": {
     "test": "ava",


### PR DESCRIPTION
Close #35 

This will require several changes in documentation, leaving `aragon-dev-cli` as binary for a bit too