### PR TITLE
Pin web3 to beta.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "semver": "^5.4.1",
     "stream-to-string": "^1.1.0",
     "tmp-promise": "^1.0.4",
-    "web3": "^1.0.0-beta.26",
+    "web3": "1.0.0-beta.26",
     "yargs": "^10.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Sigh, [web3...](https://github.com/ethereum/web3.js/issues/966#issuecomment-372706361)

Will require another release after.