### PR TITLE
Pin ganache-core to under 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ethereum-ens": "https://github.com/Arachnid/ensjs.git",
     "find-up": "^2.1.0",
     "fs-extra": "^4.0.2",
-    "ganache-core": "^2.0.2",
+    "ganache-core": "~2.0.2",
     "git-clone": "^0.1.0",
     "homedir": "^0.6.0",
     "ipfs-api": "^14.3.7",


### PR DESCRIPTION
We need to pin `ganache-core` until https://github.com/trufflesuite/ganache-core/issues/86 is resolved.