### PR TITLE
Solidity extractor: fix usages of 'function' in comment flagging declarations

### DIFF
--- a/src/helpers/solidity-extractor.js
+++ b/src/helpers/solidity-extractor.js
@@ -56,7 +56,7 @@ module.exports = async (sourceCodePath) => {
   const sourceCode = await readFile(sourceCodePath, 'utf8')
 
   // everything between every 'function' and '{' and its @notice
-  const funcDecs = sourceCode.match(/(@notice|function)(?:[^]*?){/gm)
+  const funcDecs = sourceCode.match(/(@notice|^\s*function)(?:[^]*?){/gm)
 
   if (!funcDecs) return []
 


### PR DESCRIPTION
I'm pretty sure all function declarations must be the first statement... but I could be wrong. Nobody in their right mind would do multiline function statements anyway.