### PR TITLE
Run command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,50 @@
       "resolved": "https://registry.npmjs.org/@aragon/apm/-/apm-1.0.0-beta.10.tgz",
       "integrity": "sha512-SyOJTooSrK31LUpOW2OqHXeL9mHyTfJiWVDeRBr9hVauLndLjmJaFvbKYu8P7oWCx37+YPfabiNgzEig5a7Phg==",
       "requires": {
-        "@aragon/os": "3.1.2",
+        "@aragon/os": "3.1.3",
         "ethjs-ens": "2.0.1",
         "got": "8.3.0",
         "ipfs-api": "17.5.0",
         "semver": "5.5.0"
       },
       "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "base-x": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
+          "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "bs58": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+          "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+          "requires": {
+            "base-x": "3.0.4"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
         "got": {
           "version": "8.3.0",
           "resolved": "https://registry.npmjs.org/got/-/got-8.3.0.tgz",
@@ -38,6 +75,73 @@
             "timed-out": "4.0.1",
             "url-parse-lax": "3.0.0",
             "url-to-options": "1.0.1"
+          }
+        },
+        "ipfs-api": {
+          "version": "17.5.0",
+          "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-17.5.0.tgz",
+          "integrity": "sha512-1LMao28nKBCUrvc6BUCsA3GEQ2TAoKx4Jy3BeUR3o5MVcx+dJDtXfEYDKg6WE/PWzfJF1uZGWgR9Dm2OLITR6w==",
+          "requires": {
+            "async": "2.6.0",
+            "bs58": "4.0.1",
+            "cids": "0.5.2",
+            "concat-stream": "1.6.0",
+            "detect-node": "2.0.3",
+            "flatmap": "0.0.3",
+            "glob": "7.1.2",
+            "ipfs-block": "0.6.1",
+            "ipfs-unixfs": "0.1.14",
+            "ipld-dag-pb": "0.11.4",
+            "is-ipfs": "0.3.2",
+            "is-stream": "1.1.0",
+            "lru-cache": "4.1.2",
+            "multiaddr": "3.1.0",
+            "multihashes": "0.4.13",
+            "ndjson": "1.5.0",
+            "once": "1.4.0",
+            "peer-id": "0.10.4",
+            "peer-info": "0.11.4",
+            "promisify-es6": "1.0.3",
+            "pull-defer": "0.2.2",
+            "pull-pushable": "2.2.0",
+            "pump": "2.0.1",
+            "qs": "6.5.1",
+            "readable-stream": "2.3.3",
+            "stream-http": "2.7.2",
+            "stream-to-pull-stream": "1.7.2",
+            "streamifier": "0.1.1",
+            "tar-stream": "1.5.5"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+          "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        },
+        "multiaddr": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
+          "integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
+          "requires": {
+            "bs58": "4.0.1",
+            "ip": "1.1.5",
+            "lodash.filter": "4.6.0",
+            "lodash.map": "4.6.0",
+            "varint": "5.0.0",
+            "xtend": "4.0.1"
+          }
+        },
+        "multihashes": {
+          "version": "0.4.13",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.13.tgz",
+          "integrity": "sha512-HwJGEKPCpLlNlgGQA56CYh/Wsqa+c4JAq8+mheIgw7OK5T4QvNJqgp6TH8gZ4q4l1aiWeNat/H/MrFXmTuoFfQ==",
+          "requires": {
+            "bs58": "4.0.1",
+            "varint": "5.0.0"
           }
         },
         "p-cancelable": {
@@ -63,6 +167,15 @@
           "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
           "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
         },
+        "pump": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+          "requires": {
+            "end-of-stream": "1.4.0",
+            "once": "1.4.0"
+          }
+        },
         "semver": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
@@ -79,9 +192,9 @@
       }
     },
     "@aragon/os": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@aragon/os/-/os-3.1.2.tgz",
-      "integrity": "sha512-y5MQElBTWdPU7Ul17M8VtMONpNP1VEJc7GHspjXuIvWafwsGnBxocdikj4eK47gUtX4KZZskgMBp4kIL2qkLVg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@aragon/os/-/os-3.1.3.tgz",
+      "integrity": "sha512-DehFB6Tytw+NACTULXJ1rndJhYvMtF3EMJ8+M8UDP1s8Nw/hD1O3DDJNYum6bSnUBJ7OKLdoNFZbIUsl5uo0Kg==",
       "requires": {
         "homedir": "0.6.0",
         "truffle-privatekey-provider": "0.0.5"
@@ -203,22 +316,8 @@
     "acorn": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
-    },
-    "acorn-dynamic-import": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
-      "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
-      "requires": {
-        "acorn": "4.0.13"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
-        }
-      }
+      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+      "dev": true
     },
     "acorn-jsx": {
       "version": "3.0.1",
@@ -256,17 +355,8 @@
     "ajv-keywords": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
-    },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
-      }
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "dev": true
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -343,6 +433,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "dev": true,
       "requires": {
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
@@ -366,6 +457,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "dev": true,
       "requires": {
         "arr-flatten": "1.1.0"
       }
@@ -379,7 +471,8 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
     },
     "array-differ": {
       "version": "1.0.0",
@@ -416,7 +509,8 @@
     "array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "dev": true
     },
     "array.prototype.find": {
       "version": "2.0.4",
@@ -449,23 +543,15 @@
         "minimalistic-assert": "1.0.0"
       }
     },
-    "assert": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-      "requires": {
-        "util": "0.10.3"
-      }
-    },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assertion-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
     },
     "async": {
       "version": "1.5.2",
@@ -475,7 +561,8 @@
     "async-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "dev": true
     },
     "async-eventemitter": {
       "version": "0.2.4",
@@ -504,11 +591,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "attempt-x": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/attempt-x/-/attempt-x-1.1.1.tgz",
-      "integrity": "sha512-hIp37ojJRRW8ExWSxxLpkDHUufk/DFfsb7/cUC1cVbBg7JV4gJTkCTRa44dlL9e5jx1P3VNrjL7QOQfi4MyltA=="
     },
     "auto-bind": {
       "version": "1.1.0",
@@ -822,7 +904,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "dev": true,
       "requires": {
         "babel-helper-explode-assignable-expression": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -855,7 +936,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-traverse": "6.26.0",
@@ -915,7 +995,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "dev": true,
       "requires": {
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -980,26 +1059,22 @@
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-      "dev": true
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-      "dev": true
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
     },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
-      "dev": true
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
     },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "dev": true,
       "requires": {
         "babel-helper-remap-async-to-generator": "6.24.1",
         "babel-plugin-syntax-async-functions": "6.13.0",
@@ -1222,7 +1297,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "dev": true,
       "requires": {
         "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
         "babel-plugin-syntax-exponentiation-operator": "6.13.0",
@@ -1244,6 +1318,43 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
+      }
+    },
+    "babel-preset-env": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
+      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+      "requires": {
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "browserslist": "2.11.3",
+        "invariant": "2.2.2",
+        "semver": "5.4.1"
       }
     },
     "babel-preset-es2015": {
@@ -1377,20 +1488,11 @@
         "tweetnacl": "0.14.5"
       }
     },
-    "big.js": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
-    },
-    "bignumber.js": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
-      "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
-    },
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+      "dev": true
     },
     "bindings": {
       "version": "1.3.0",
@@ -1553,6 +1655,7 @@
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "dev": true,
       "requires": {
         "expand-range": "1.8.2",
         "preserve": "0.2.0",
@@ -1640,12 +1743,13 @@
         "parse-asn1": "5.1.0"
       }
     },
-    "browserify-zlib": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+    "browserslist": {
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+      "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
       "requires": {
-        "pako": "1.0.6"
+        "caniuse-lite": "1.0.30000820",
+        "electron-to-chromium": "1.3.40"
       }
     },
     "bs58": {
@@ -1671,35 +1775,15 @@
       "integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o=",
       "dev": true
     },
-    "buffer": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-      "requires": {
-        "base64-js": "1.2.1",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        }
-      }
-    },
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "buffer-from": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.1.tgz",
-      "integrity": "sha1-V7GLHaChnsBvM4N6UnWiQjUb114=",
-      "requires": {
-        "is-array-buffer-x": "1.7.0"
-      }
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+      "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
     },
     "buffer-loader": {
       "version": "0.0.1",
@@ -1761,11 +1845,6 @@
         "normalize-url": "2.0.1",
         "responselike": "1.0.2"
       }
-    },
-    "cached-constructors-x": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cached-constructors-x/-/cached-constructors-x-1.0.0.tgz",
-      "integrity": "sha512-JVP0oilYlPgBTD8bkQ+of7hSIJRtydCCJiMtzdRMXVQ98gdj0NyrJTZzbu5wtlO26Ev/1HXRTtbBNsVlLJ3+3A=="
     },
     "cachedown": {
       "version": "1.0.0",
@@ -1865,6 +1944,11 @@
         }
       }
     },
+    "caniuse-lite": {
+      "version": "1.0.30000820",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000820.tgz",
+      "integrity": "sha512-E0dpVjnt1XTNmWlGgdiae/tOF0jrJ/s+dOnwk8PLmPdu5uSu8wTLJhhbhcgUWU4aO9Iy5yUMZYxT60JS259sbQ=="
+    },
     "capture-stack-trace": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
@@ -1876,21 +1960,12 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
-      }
-    },
     "chai": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "requires": {
-        "assertion-error": "1.0.2",
+        "assertion-error": "1.1.0",
         "deep-eql": "0.1.3",
         "type-detect": "1.0.0"
       }
@@ -1917,6 +1992,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "dev": true,
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
@@ -2215,19 +2291,6 @@
         "xdg-basedir": "3.0.0"
       }
     },
-    "console-browserify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "requires": {
-        "date-now": "0.1.4"
-      }
-    },
-    "constants-browserify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
-    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -2458,11 +2521,6 @@
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
       "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw=="
-    },
-    "date-now": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
     },
     "date-time": {
       "version": "2.1.0",
@@ -2768,11 +2826,6 @@
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
       "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
-    "domain-browser": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-      "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
-    },
     "dot-prop": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
@@ -2811,6 +2864,11 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "electron-to-chromium": {
+      "version": "1.3.40",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.40.tgz",
+      "integrity": "sha1-H71tl779crim+SHcONIkE9L2/d8="
+    },
     "elegant-spinner": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
@@ -2829,11 +2887,6 @@
         "minimalistic-assert": "1.0.0",
         "minimalistic-crypto-utils": "1.0.1"
       }
-    },
-    "emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
     "empower-core": {
       "version": "0.6.2",
@@ -2864,17 +2917,6 @@
       "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
       "requires": {
         "once": "1.4.0"
-      }
-    },
-    "enhanced-resolve": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
-      "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "object-assign": "4.1.1",
-        "tapable": "0.2.8"
       }
     },
     "equal-length": {
@@ -3330,6 +3372,51 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "eth-block-tracker": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-2.3.0.tgz",
+      "integrity": "sha512-yrNyBIBKC7WfUjrXSG/CZVy0gW2aF8+MnjnrkOxkZOR+BAtL6JgYOnzVnrU8KE6mKJETlA/1dYMygvLXWyJGGw==",
+      "requires": {
+        "async-eventemitter": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+        "eth-query": "2.1.2",
+        "ethereumjs-tx": "1.3.3",
+        "ethereumjs-util": "5.1.5",
+        "ethjs-util": "0.1.4",
+        "json-rpc-engine": "3.6.1",
+        "pify": "2.3.0",
+        "tape": "4.8.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "async-eventemitter": {
+          "version": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+          "requires": {
+            "async": "2.6.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.5.tgz",
+          "integrity": "sha512-xPaSEATYJpMTCGowIt0oMZwFP4R1bxd6QsWgkcDvFL0JtXsr39p32WEcD14RscCjfP41YXZPCVWA4yAg0nrJmw==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "create-hash": "1.1.3",
+            "ethjs-util": "0.1.4",
+            "keccak": "1.4.0",
+            "rlp": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "secp256k1": "3.4.0"
+          }
+        }
+      }
+    },
     "eth-ens-namehash": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
@@ -3360,6 +3447,24 @@
         "xhr-request-promise": "0.1.2"
       }
     },
+    "eth-query": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/eth-query/-/eth-query-2.1.2.tgz",
+      "integrity": "sha1-1nQdkAAQa1FRDHLbktY2VFam2l4=",
+      "requires": {
+        "json-rpc-random-id": "1.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "eth-sig-util": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
+      "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
+      "requires": {
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
+        "ethereumjs-util": "5.1.2"
+      }
+    },
     "ethereum-common": {
       "version": "0.0.16",
       "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.16.tgz",
@@ -3369,6 +3474,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ethereum-ens-network-map/-/ethereum-ens-network-map-1.0.0.tgz",
       "integrity": "sha1-Q812ac6VCnieFRABEY1NZfIQ7rc="
+    },
+    "ethereumjs-abi": {
+      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
+      "requires": {
+        "bn.js": "4.11.8",
+        "ethereumjs-util": "5.1.2"
+      }
     },
     "ethereumjs-account": {
       "version": "2.0.4",
@@ -3721,11 +3833,6 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
       "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA="
     },
-    "events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
-    },
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -3758,6 +3865,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "dev": true,
       "requires": {
         "is-posix-bracket": "0.1.1"
       }
@@ -3766,6 +3874,7 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
       "requires": {
         "fill-range": "2.2.3"
       }
@@ -3823,6 +3932,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "dev": true,
       "requires": {
         "is-extglob": "1.0.0"
       }
@@ -3870,6 +3980,14 @@
         "pend": "1.2.0"
       }
     },
+    "fetch-ponyfill": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz",
+      "integrity": "sha1-rjzl9zLGReq4fkroeTQUcJsjmJM=",
+      "requires": {
+        "node-fetch": "1.7.3"
+      }
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -3896,12 +4014,14 @@
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "dev": true
     },
     "fill-range": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "dev": true,
       "requires": {
         "is-number": "2.1.0",
         "isobject": "2.1.0",
@@ -3983,12 +4103,14 @@
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
     },
     "for-own": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "dev": true,
       "requires": {
         "for-in": "1.0.2"
       }
@@ -4081,6 +4203,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
       "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "dev": true,
       "optional": true,
       "requires": {
         "nan": "2.8.0",
@@ -4089,12 +4212,16 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+          "dev": true,
           "optional": true
         },
         "ajv": {
           "version": "4.11.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true,
           "optional": true,
           "requires": {
             "co": "4.6.0",
@@ -4103,16 +4230,22 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
         },
         "aproba": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+          "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "dev": true,
           "optional": true,
           "requires": {
             "delegates": "1.0.0",
@@ -4121,36 +4254,50 @@
         },
         "asn1": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+          "dev": true,
           "optional": true
         },
         "assert-plus": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "dev": true,
           "optional": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+          "dev": true,
           "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "dev": true,
           "optional": true
         },
         "aws4": {
           "version": "1.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+          "dev": true,
           "optional": true
         },
         "balanced-match": {
           "version": "0.4.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+          "dev": true,
           "optional": true,
           "requires": {
             "tweetnacl": "0.14.5"
@@ -4158,21 +4305,27 @@
         },
         "block-stream": {
           "version": "0.0.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+          "dev": true,
           "requires": {
             "inherits": "2.0.3"
           }
         },
         "boom": {
           "version": "2.10.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "dev": true,
           "requires": {
             "hoek": "2.16.3"
           }
         },
         "brace-expansion": {
           "version": "1.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+          "dev": true,
           "requires": {
             "balanced-match": "0.4.2",
             "concat-map": "0.0.1"
@@ -4180,51 +4333,71 @@
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+          "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+          "dev": true,
           "optional": true
         },
         "co": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+          "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "dev": true,
           "requires": {
             "delayed-stream": "1.0.0"
           }
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "dev": true,
           "requires": {
             "boom": "2.10.1"
           }
         },
         "dashdash": {
           "version": "1.14.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "dev": true,
           "optional": true,
           "requires": {
             "assert-plus": "1.0.0"
@@ -4232,14 +4405,18 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "dev": true,
               "optional": true
             }
           }
         },
         "debug": {
           "version": "2.6.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
           "optional": true,
           "requires": {
             "ms": "2.0.0"
@@ -4247,26 +4424,36 @@
         },
         "deep-extend": {
           "version": "0.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+          "dev": true,
           "optional": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+          "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
+          "integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
+          "dev": true,
           "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+          "dev": true,
           "optional": true,
           "requires": {
             "jsbn": "0.1.1"
@@ -4274,21 +4461,29 @@
         },
         "extend": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+          "dev": true,
           "optional": true
         },
         "extsprintf": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+          "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+          "dev": true,
           "optional": true
         },
         "form-data": {
           "version": "2.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "dev": true,
           "optional": true,
           "requires": {
             "asynckit": "0.4.0",
@@ -4298,11 +4493,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "dev": true
         },
         "fstream": {
           "version": "1.0.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "inherits": "2.0.3",
@@ -4312,7 +4511,9 @@
         },
         "fstream-ignore": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+          "dev": true,
           "optional": true,
           "requires": {
             "fstream": "1.0.11",
@@ -4322,7 +4523,9 @@
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "dev": true,
           "optional": true,
           "requires": {
             "aproba": "1.1.1",
@@ -4337,7 +4540,9 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "dev": true,
           "optional": true,
           "requires": {
             "assert-plus": "1.0.0"
@@ -4345,14 +4550,18 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "dev": true,
               "optional": true
             }
           }
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -4364,16 +4573,22 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+          "dev": true,
           "optional": true
         },
         "har-validator": {
           "version": "4.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "dev": true,
           "optional": true,
           "requires": {
             "ajv": "4.11.8",
@@ -4382,12 +4597,16 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "dev": true,
           "optional": true
         },
         "hawk": {
           "version": "3.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "dev": true,
           "requires": {
             "boom": "2.10.1",
             "cryptiles": "2.0.5",
@@ -4397,11 +4616,15 @@
         },
         "hoek": {
           "version": "2.16.3",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "dev": true,
           "optional": true,
           "requires": {
             "assert-plus": "0.2.0",
@@ -4411,7 +4634,9 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "dev": true,
           "requires": {
             "once": "1.4.0",
             "wrappy": "1.0.2"
@@ -4419,37 +4644,51 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+          "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+          "dev": true,
           "optional": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+          "dev": true,
           "optional": true
         },
         "jodid25519": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+          "dev": true,
           "optional": true,
           "requires": {
             "jsbn": "0.1.1"
@@ -4457,17 +4696,23 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+          "dev": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+          "dev": true,
           "optional": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+          "dev": true,
           "optional": true,
           "requires": {
             "jsonify": "0.0.0"
@@ -4475,17 +4720,23 @@
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+          "dev": true,
           "optional": true
         },
         "jsonify": {
           "version": "0.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+          "dev": true,
           "optional": true
         },
         "jsprim": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+          "dev": true,
           "optional": true,
           "requires": {
             "assert-plus": "1.0.0",
@@ -4496,48 +4747,64 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "dev": true,
               "optional": true
             }
           }
         },
         "mime-db": {
           "version": "1.27.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+          "dev": true
         },
         "mime-types": {
           "version": "2.1.15",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+          "dev": true,
           "requires": {
             "mime-db": "1.27.0"
           }
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
           "requires": {
             "brace-expansion": "1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true,
           "optional": true
         },
         "node-pre-gyp": {
           "version": "0.6.39",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+          "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
+          "dev": true,
           "optional": true,
           "requires": {
             "detect-libc": "1.0.2",
@@ -4555,7 +4822,9 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "dev": true,
           "optional": true,
           "requires": {
             "abbrev": "1.1.0",
@@ -4564,7 +4833,9 @@
         },
         "npmlog": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
+          "dev": true,
           "optional": true,
           "requires": {
             "are-we-there-yet": "1.1.4",
@@ -4575,38 +4846,52 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+          "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "dev": true,
           "requires": {
             "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+          "dev": true,
           "optional": true,
           "requires": {
             "os-homedir": "1.0.2",
@@ -4615,30 +4900,42 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "dev": true
         },
         "performance-now": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+          "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true
         },
         "punycode": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true,
           "optional": true
         },
         "qs": {
           "version": "6.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+          "dev": true,
           "optional": true,
           "requires": {
             "deep-extend": "0.4.2",
@@ -4649,14 +4946,18 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true,
               "optional": true
             }
           }
         },
         "readable-stream": {
           "version": "2.2.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+          "dev": true,
           "requires": {
             "buffer-shims": "1.0.0",
             "core-util-is": "1.0.2",
@@ -4669,7 +4970,9 @@
         },
         "request": {
           "version": "2.81.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "dev": true,
           "optional": true,
           "requires": {
             "aws-sign2": "0.6.0",
@@ -4698,40 +5001,54 @@
         },
         "rimraf": {
           "version": "2.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+          "dev": true,
           "requires": {
             "glob": "7.1.2"
           }
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+          "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "dev": true,
           "optional": true
         },
         "sntp": {
           "version": "1.0.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "dev": true,
           "requires": {
             "hoek": "2.16.3"
           }
         },
         "sshpk": {
           "version": "1.13.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+          "dev": true,
           "optional": true,
           "requires": {
             "asn1": "0.2.3",
@@ -4747,14 +5064,18 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "dev": true,
               "optional": true
             }
           }
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -4763,31 +5084,41 @@
         },
         "string_decoder": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "dev": true,
           "requires": {
             "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
           "version": "0.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+          "dev": true,
           "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true,
           "optional": true
         },
         "tar": {
           "version": "2.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "dev": true,
           "requires": {
             "block-stream": "0.0.9",
             "fstream": "1.0.11",
@@ -4796,7 +5127,9 @@
         },
         "tar-pack": {
           "version": "3.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+          "dev": true,
           "optional": true,
           "requires": {
             "debug": "2.6.8",
@@ -4811,7 +5144,9 @@
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+          "dev": true,
           "optional": true,
           "requires": {
             "punycode": "1.4.1"
@@ -4819,7 +5154,9 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "dev": true,
           "optional": true,
           "requires": {
             "safe-buffer": "5.0.1"
@@ -4827,26 +5164,36 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "dev": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+          "dev": true,
           "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "dev": true
         },
         "uuid": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+          "dev": true,
           "optional": true
         },
         "verror": {
           "version": "1.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+          "dev": true,
           "optional": true,
           "requires": {
             "extsprintf": "1.0.2"
@@ -4854,7 +5201,9 @@
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "dev": true,
           "optional": true,
           "requires": {
             "string-width": "1.0.2"
@@ -4862,7 +5211,9 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "dev": true
         }
       }
     },
@@ -4894,20 +5245,22 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "ganache-core": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ganache-core/-/ganache-core-2.0.2.tgz",
-      "integrity": "sha512-hfmfqwWDT7zLPwSmAHXExCP8S97yjqGaT7KS93tKj4DY6beU8na46bkH1GZUb02DKXqHC4deTv85xA1yBwV1Lw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ganache-core/-/ganache-core-2.1.0.tgz",
+      "integrity": "sha512-zUO61d23XHBCYOUjEQjIuENcfa6EQNBHKuG2oXWdTdGyu5Gbm4fXX9klZ2jjl9ZnBD2T4BaeBXycsLmL0S/d2w==",
       "requires": {
-        "async": "1.5.2",
+        "abstract-leveldown": "3.0.0",
+        "async": "2.6.0",
         "bip39": "2.4.0",
+        "bn.js": "4.11.6",
         "cachedown": "1.0.0",
         "chai": "3.5.0",
         "clone": "2.1.1",
         "ethereumjs-account": "2.0.4",
         "ethereumjs-block": "1.2.2",
         "ethereumjs-tx": "1.3.3",
-        "ethereumjs-util": "5.1.2",
-        "ethereumjs-vm": "2.3.2",
+        "ethereumjs-util": "5.1.5",
+        "ethereumjs-vm": "2.3.3",
         "ethereumjs-wallet": "0.6.0",
         "fake-merkle-patricia-tree": "1.0.1",
         "heap": "0.2.6",
@@ -4915,31 +5268,116 @@
         "level-sublevel": "6.6.1",
         "levelup": "1.3.9",
         "localstorage-down": "0.6.7",
+        "lodash": "4.17.5",
         "merkle-patricia-tree": "2.3.0",
         "mocha": "3.3.0",
-        "on-build-webpack": "0.1.0",
+        "pify": "3.0.0",
         "prepend-file": "1.3.1",
         "seedrandom": "2.4.3",
         "shebang-loader": "0.0.1",
         "solc": "0.4.18",
         "temp": "0.8.3",
         "tmp": "0.0.31",
-        "web3": "0.19.1",
-        "web3-provider-engine": "8.1.19",
-        "webpack": "2.7.0",
+        "web3": "1.0.0-beta.33",
+        "web3-provider-engine": "13.6.6",
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
         "yargs": "7.1.0"
       },
       "dependencies": {
-        "web3": {
-          "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/web3/-/web3-0.19.1.tgz",
-          "integrity": "sha1-52PVsRB8S8JKvU+MvuG6Nlnm6zE=",
+        "abstract-leveldown": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-3.0.0.tgz",
+          "integrity": "sha512-KUWx9UWGQD12zsmLNj64/pndaz4iJh/Pj7nopgkfDG6RlCcbMZvT6+9l7dchK4idog2Is8VdC/PvNbFuFmalIQ==",
           "requires": {
-            "bignumber.js": "4.1.0",
-            "crypto-js": "3.1.8",
-            "utf8": "2.1.2",
-            "xhr2": "0.1.4",
-            "xmlhttprequest": "1.8.0"
+            "xtend": "4.0.1"
+          }
+        },
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "requires": {
+            "lodash": "4.17.5"
+          }
+        },
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        },
+        "ethereum-common": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+          "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
+        },
+        "ethereumjs-util": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.1.5.tgz",
+          "integrity": "sha512-xPaSEATYJpMTCGowIt0oMZwFP4R1bxd6QsWgkcDvFL0JtXsr39p32WEcD14RscCjfP41YXZPCVWA4yAg0nrJmw==",
+          "requires": {
+            "bn.js": "4.11.6",
+            "create-hash": "1.1.3",
+            "ethjs-util": "0.1.4",
+            "keccak": "1.4.0",
+            "rlp": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "secp256k1": "3.4.0"
+          }
+        },
+        "ethereumjs-vm": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.3.tgz",
+          "integrity": "sha512-yIWJqTEcrF9vJTCvNMxacRkAx6zIZTOW0SmSA+hSFiU1x8JyVZDi9o5udwsRVECT5RkPgQzm62kpL6Pf4qemsw==",
+          "requires": {
+            "async": "2.6.0",
+            "async-eventemitter": "0.2.4",
+            "ethereum-common": "0.2.0",
+            "ethereumjs-account": "2.0.4",
+            "ethereumjs-block": "1.7.1",
+            "ethereumjs-util": "5.1.5",
+            "fake-merkle-patricia-tree": "1.0.1",
+            "functional-red-black-tree": "1.0.1",
+            "merkle-patricia-tree": "2.3.0",
+            "rustbn.js": "0.1.1",
+            "safe-buffer": "5.1.1"
+          },
+          "dependencies": {
+            "ethereumjs-block": {
+              "version": "1.7.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+              "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
+              "requires": {
+                "async": "2.6.0",
+                "ethereum-common": "0.2.0",
+                "ethereumjs-tx": "1.3.3",
+                "ethereumjs-util": "5.1.5",
+                "merkle-patricia-tree": "2.3.0"
+              }
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
+        "web3": {
+          "version": "1.0.0-beta.33",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.33.tgz",
+          "integrity": "sha1-xgIbV2mSdyY3HBhLhoRFMRsTkpU=",
+          "requires": {
+            "web3-bzz": "1.0.0-beta.33",
+            "web3-core": "1.0.0-beta.33",
+            "web3-eth": "1.0.0-beta.33",
+            "web3-eth-personal": "1.0.0-beta.33",
+            "web3-net": "1.0.0-beta.33",
+            "web3-shh": "1.0.0-beta.33",
+            "web3-utils": "1.0.0-beta.33"
           }
         },
         "yargs": {
@@ -5044,15 +5482,22 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "dev": true,
       "requires": {
         "glob-parent": "2.0.0",
         "is-glob": "2.0.1"
       }
     },
+    "glob-escape": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/glob-escape/-/glob-escape-0.0.2.tgz",
+      "integrity": "sha1-nCf3gh7RwTd1gvPv2VWOP2dWKO0="
+    },
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "dev": true,
       "requires": {
         "is-glob": "2.0.1"
       }
@@ -5174,16 +5619,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-localstorage/-/has-localstorage-1.0.1.tgz",
       "integrity": "sha1-/mJAbEdn+9bXhNrGkFkoEIuClxs="
-    },
-    "has-own-property-x": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz",
-      "integrity": "sha512-HtRQTYpRFz/YVaQ7jh2mU5iorMAxFcML9FNOLMI1f8VNJ2K0hpOlXoi1a+nmVl6oUcGnhd6zYOFAVe7NUFStyQ==",
-      "requires": {
-        "cached-constructors-x": "1.0.0",
-        "to-object-x": "1.5.0",
-        "to-property-key-x": "2.0.2"
-      }
     },
     "has-symbol-support-x": {
       "version": "1.4.1",
@@ -5324,11 +5759,6 @@
         "sshpk": "1.13.1"
       }
     },
-    "https-browserify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
-      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
-    },
     "hullabaloo-config-manager": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/hullabaloo-config-manager/-/hullabaloo-config-manager-1.1.1.tgz",
@@ -5428,16 +5858,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
       "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
-    },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
-    },
-    "infinity-x": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/infinity-x/-/infinity-x-1.0.0.tgz",
-      "integrity": "sha512-wjy2TupBtZ+aAniKt+xs/PO0xOkuaL6wBysUKbgD7aL1PMW/qY5xXDG59zXZ7dU+gk3zwXOu4yIEWPCEFBTgHQ=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -5551,7 +5971,8 @@
     "interpret": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "dev": true
     },
     "into-stream": {
       "version": "3.1.0",
@@ -5586,9 +6007,9 @@
       "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
     },
     "ipfs-api": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-17.5.0.tgz",
-      "integrity": "sha512-1LMao28nKBCUrvc6BUCsA3GEQ2TAoKx4Jy3BeUR3o5MVcx+dJDtXfEYDKg6WE/PWzfJF1uZGWgR9Dm2OLITR6w==",
+      "version": "14.3.7",
+      "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-14.3.7.tgz",
+      "integrity": "sha512-SeCKT6KwMuu/qDEMDd5CRj2KhSa1+Dyx63jJgadU2tD6QINyxCy/ooPFBhZRwlGuAhb61IVSV8pfZ0nHNQEINQ==",
       "requires": {
         "async": "2.6.0",
         "bs58": "4.0.1",
@@ -5597,26 +6018,25 @@
         "detect-node": "2.0.3",
         "flatmap": "0.0.3",
         "glob": "7.1.2",
+        "glob-escape": "0.0.2",
         "ipfs-block": "0.6.1",
         "ipfs-unixfs": "0.1.14",
         "ipld-dag-pb": "0.11.4",
         "is-ipfs": "0.3.2",
         "is-stream": "1.1.0",
-        "lru-cache": "4.1.2",
-        "multiaddr": "3.1.0",
-        "multihashes": "0.4.13",
+        "lru-cache": "4.1.1",
+        "multiaddr": "3.0.1",
+        "multihashes": "0.4.12",
+        "multipart-stream": "2.0.1",
         "ndjson": "1.5.0",
         "once": "1.4.0",
         "peer-id": "0.10.4",
         "peer-info": "0.11.4",
         "promisify-es6": "1.0.3",
-        "pull-defer": "0.2.2",
-        "pull-pushable": "2.2.0",
-        "pump": "2.0.1",
+        "pump": "1.0.3",
         "qs": "6.5.1",
         "readable-stream": "2.3.3",
         "stream-http": "2.7.2",
-        "stream-to-pull-stream": "1.7.2",
         "streamifier": "0.1.1",
         "tar-stream": "1.5.5"
       },
@@ -5630,9 +6050,9 @@
           }
         },
         "base-x": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
-          "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.3.tgz",
+          "integrity": "sha512-qKXPTB94LxXhJs8hqwTdyVTiDXMFTRUFj5F7FnWOW19ALCfANf2lHHUnEcY43g3DaVi4X8E2oDCkHIN8bjr32Q==",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -5642,7 +6062,7 @@
           "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
           "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
           "requires": {
-            "base-x": "3.0.4"
+            "base-x": "3.0.3"
           }
         },
         "glob": {
@@ -5659,40 +6079,13 @@
           }
         },
         "lru-cache": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-          "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
           "requires": {
             "pseudomap": "1.0.2",
             "yallist": "2.1.2"
           }
-        },
-        "multiaddr": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
-          "integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
-          "requires": {
-            "bs58": "4.0.1",
-            "ip": "1.1.5",
-            "lodash.filter": "4.6.0",
-            "lodash.map": "4.6.0",
-            "varint": "5.0.0",
-            "xtend": "4.0.1"
-          }
-        },
-        "multihashes": {
-          "version": "0.4.13",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.13.tgz",
-          "integrity": "sha512-HwJGEKPCpLlNlgGQA56CYh/Wsqa+c4JAq8+mheIgw7OK5T4QvNJqgp6TH8gZ4q4l1aiWeNat/H/MrFXmTuoFfQ==",
-          "requires": {
-            "bs58": "4.0.1",
-            "varint": "5.0.0"
-          }
-        },
-        "pull-pushable": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
-          "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE="
         }
       }
     },
@@ -5763,18 +6156,6 @@
       "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
       "dev": true
     },
-    "is-array-buffer-x": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/is-array-buffer-x/-/is-array-buffer-x-1.7.0.tgz",
-      "integrity": "sha512-ufSZRMY2WZX5xyNvk0NOZAG7cgi35B/sGQDGqv8w0X7MoQ2GC9vedanJhuYTPaC4PUCqLQsda1w7NF+dPZmAJw==",
-      "requires": {
-        "attempt-x": "1.1.1",
-        "has-to-string-tag-x": "1.4.1",
-        "is-object-like-x": "1.6.0",
-        "object-get-own-property-descriptor-x": "3.2.0",
-        "to-string-tag-x": "1.4.2"
-      }
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -5784,6 +6165,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true,
       "requires": {
         "binary-extensions": "1.11.0"
       }
@@ -5791,7 +6173,8 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -5823,12 +6206,14 @@
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "dev": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "dev": true,
       "requires": {
         "is-primitive": "2.0.0"
       }
@@ -5842,20 +6227,14 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
     },
     "is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-    },
-    "is-falsey-x": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-falsey-x/-/is-falsey-x-1.0.1.tgz",
-      "integrity": "sha512-XWNZC4A+3FX1ECoMjspuEFgSdio82IWjqY/suE0gZ10QA7nzHd/KraRq7Tc5VEHtFRgTRyTdY6W+ykPrDnyoAQ==",
-      "requires": {
-        "to-boolean-x": "1.0.1"
-      }
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -5865,14 +6244,10 @@
         "number-is-nan": "1.0.1"
       }
     },
-    "is-finite-x": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.2.tgz",
-      "integrity": "sha512-HyFrxJZsgmP5RtR1PVlVvHSP4VslZOqr4uoq4x3rDrSOFaYp4R9tfmiWtAzQxPzixXhac3cYEno3NuVn0OHk2Q==",
-      "requires": {
-        "infinity-x": "1.0.0",
-        "is-nan-x": "1.0.1"
-      }
+    "is-fn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fn/-/is-fn-1.0.0.tgz",
+      "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw="
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
@@ -5887,21 +6262,6 @@
       "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
       "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
     },
-    "is-function-x": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz",
-      "integrity": "sha512-SreSSU1dlgYaXR5c0mm4qJHKYHIiGiEY+7Cd8/aRLLoMP/VvofD2XcWgBnP833ajpU5XzXbUSpfysnfKZLJFlg==",
-      "requires": {
-        "attempt-x": "1.1.1",
-        "has-to-string-tag-x": "1.4.1",
-        "is-falsey-x": "1.0.1",
-        "is-primitive": "2.0.0",
-        "normalize-space-x": "3.0.0",
-        "replace-comments-x": "2.0.0",
-        "to-boolean-x": "1.0.1",
-        "to-string-tag-x": "1.4.2"
-      }
-    },
     "is-generator-fn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
@@ -5912,6 +6272,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "dev": true,
       "requires": {
         "is-extglob": "1.0.0"
       }
@@ -5920,18 +6281,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
       "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
-    },
-    "is-index-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz",
-      "integrity": "sha512-qULKLMepQLGC8rSVdi8uF2vI4LiDrU9XSDg1D+Aa657GIB7GV1jHpga7uXgQvkt/cpQ5mVBHUFTpSehYSqT6+A==",
-      "requires": {
-        "math-clamp-x": "1.2.0",
-        "max-safe-integer": "1.0.1",
-        "to-integer-x": "3.0.0",
-        "to-number-x": "2.0.0",
-        "to-string-symbols-supported-x": "1.0.0"
-      }
     },
     "is-installed-globally": {
       "version": "0.1.0",
@@ -5983,24 +6332,10 @@
         "xtend": "4.0.1"
       }
     },
-    "is-nan-x": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-nan-x/-/is-nan-x-1.0.1.tgz",
-      "integrity": "sha512-VfNJgfuT8USqKCYQss8g7sFvCzDnL+OOVMQoXhVoulZAyp0ZTj3oyZaaPrn2dxepAkKSQI2BiKHbBabX1DqVtw=="
-    },
     "is-natural-number": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
       "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
-    },
-    "is-nil-x": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.1.tgz",
-      "integrity": "sha512-cfTKWI5iSR04SSCzzugTH5tS2rYG7kwI8yl/AqWkyuxZ7k55cbA47Y7Lezdg1N9aaELd+UxLg628bdQeNQ6BUw==",
-      "requires": {
-        "lodash.isnull": "3.0.0",
-        "validate.io-undefined": "1.0.3"
-      }
     },
     "is-npm": {
       "version": "1.0.0",
@@ -6012,6 +6347,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "dev": true,
       "requires": {
         "kind-of": "3.2.2"
       }
@@ -6026,15 +6362,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
-    },
-    "is-object-like-x": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.6.0.tgz",
-      "integrity": "sha512-mc3dBMv1jEOdk0f1i2RkJFsZDux0MuHqGwHOoRo770ShUOf4VE6tWThAW8dAZARr9a5RN+iNX1yzMDA5ad1clQ==",
-      "requires": {
-        "is-function-x": "3.3.0",
-        "is-primitive": "2.0.0"
-      }
     },
     "is-observable": {
       "version": "0.2.0",
@@ -6076,12 +6403,14 @@
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "dev": true
     },
     "is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "dev": true
     },
     "is-promise": {
       "version": "1.0.1",
@@ -6124,11 +6453,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
-    "is-string": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
-      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ="
-    },
     "is-symbol": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
@@ -6164,6 +6488,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
       "requires": {
         "isarray": "1.0.0"
       },
@@ -6171,7 +6496,8 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
         }
       }
     },
@@ -6181,7 +6507,7 @@
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
         "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
+        "whatwg-fetch": "2.0.4"
       }
     },
     "isstream": {
@@ -6248,10 +6574,40 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
     },
-    "json-loader": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w=="
+    "json-rpc-engine": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-3.6.1.tgz",
+      "integrity": "sha512-xYuD9M1pcld5OKPzVAoEG5MKtnR8iKMyNzRpeS3/mCJ7dcAcS67vqfOmYLoaIQfVRU5uClThbjri3VFR0vEwYg==",
+      "requires": {
+        "async": "2.6.0",
+        "babel-preset-env": "1.6.1",
+        "babelify": "7.3.0",
+        "json-rpc-error": "2.0.0",
+        "promise-to-callback": "1.0.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        }
+      }
+    },
+    "json-rpc-error": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-error/-/json-rpc-error-2.0.0.tgz",
+      "integrity": "sha1-p6+cICg4tekFxyUOVH8a/3cligI=",
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "json-rpc-random-id": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz",
+      "integrity": "sha1-uknZat7RRE27jaPSA3SKy7zeyMg="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -6364,6 +6720,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
       "requires": {
         "is-buffer": "1.1.6"
       }
@@ -6393,11 +6750,6 @@
       "requires": {
         "package-json": "4.0.1"
       }
-    },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
     },
     "lcid": {
       "version": "1.0.0",
@@ -6451,9 +6803,9 @@
       }
     },
     "level-post": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.5.tgz",
-      "integrity": "sha1-KmY5BAm/ahYhpES6tvAWREzJgCw=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
+      "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
       "requires": {
         "ltgt": "2.2.0"
       }
@@ -6466,7 +6818,7 @@
         "bytewise": "1.1.0",
         "levelup": "0.19.1",
         "ltgt": "2.1.3",
-        "pull-level": "2.0.3",
+        "pull-level": "2.0.4",
         "pull-stream": "3.6.1",
         "typewiselite": "1.0.0",
         "xtend": "4.0.1"
@@ -6656,6 +7008,9 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -6910,22 +7265,6 @@
         "strip-bom": "2.0.0"
       }
     },
-    "loader-runner": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
-      "integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI="
-    },
-    "loader-utils": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-      "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-      "requires": {
-        "big.js": "3.2.0",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1",
-        "object-assign": "4.1.1"
-      }
-    },
     "localstorage-down": {
       "version": "0.6.7",
       "resolved": "https://registry.npmjs.org/localstorage-down/-/localstorage-down-0.6.7.tgz",
@@ -6933,7 +7272,7 @@
       "requires": {
         "abstract-leveldown": "0.12.3",
         "argsarray": "0.0.1",
-        "buffer-from": "0.1.1",
+        "buffer-from": "0.1.2",
         "d64": "1.0.0",
         "humble-localstorage": "1.4.2",
         "inherits": "2.0.3",
@@ -7081,11 +7420,6 @@
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
-    "lodash.isnull": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isnull/-/lodash.isnull-3.0.0.tgz",
-      "integrity": "sha1-+vvlnqHcon7teGU0A53YTC4HxW4="
-    },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
@@ -7188,11 +7522,6 @@
         }
       }
     },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
-    },
     "looper": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
@@ -7264,28 +7593,6 @@
         "escape-string-regexp": "1.0.5"
       }
     },
-    "math-clamp-x": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
-      "integrity": "sha512-tqpjpBcIf9UulApz3EjWXqTZpMlr2vLN9PryC9ghoyCuRmqZaf3JJhPddzgQpJnKLi2QhoFnvKBFtJekAIBSYg==",
-      "requires": {
-        "to-number-x": "2.0.0"
-      }
-    },
-    "math-sign-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz",
-      "integrity": "sha512-OzPas41Pn4d16KHnaXmGxxY3/l3zK4OIXtmIwdhgZsxz4FDDcNnbrABYPg2vGfxIkaT9ezGnzDviRH7RfF44jQ==",
-      "requires": {
-        "is-nan-x": "1.0.1",
-        "to-number-x": "2.0.0"
-      }
-    },
-    "max-safe-integer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/max-safe-integer/-/max-safe-integer-1.0.1.tgz",
-      "integrity": "sha1-84BgvixWPYwC5tSK85Ei/YO29BA="
-    },
     "md5-hex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
@@ -7345,15 +7652,6 @@
         "inherits": "2.0.3",
         "ltgt": "2.2.0",
         "safe-buffer": "5.1.1"
-      }
-    },
-    "memory-fs": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-      "requires": {
-        "errno": "0.1.6",
-        "readable-stream": "2.3.3"
       }
     },
     "memorystream": {
@@ -7416,6 +7714,7 @@
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "dev": true,
       "requires": {
         "arr-diff": "2.0.0",
         "array-unique": "0.2.1",
@@ -7698,6 +7997,16 @@
         "minimatch": "3.0.4"
       }
     },
+    "multipart-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/multipart-stream/-/multipart-stream-2.0.1.tgz",
+      "integrity": "sha1-GVyctLLEHnjHKh6POMfQ66HNC6A=",
+      "requires": {
+        "inherits": "2.0.3",
+        "is-stream": "1.1.0",
+        "sandwich-stream": "1.0.0"
+      }
+    },
     "murmurhash3js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/murmurhash3js/-/murmurhash3js-3.0.1.tgz",
@@ -7723,11 +8032,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
       "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
-    },
-    "nan-x": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nan-x/-/nan-x-1.0.0.tgz",
-      "integrity": "sha512-yw4Fhe2/UTzanQ4f0yHWkRnfTuHZFAi4GZDjXS4G+qv5BqXTqPJBbSxpa7MyyW9v4Y4ZySZQik1vcbNkhdnIOg=="
     },
     "nano-json-stream-parser": {
       "version": "0.1.2",
@@ -7777,56 +8081,6 @@
         "is-stream": "1.1.0"
       }
     },
-    "node-libs-browser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
-      "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
-      "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.2.0",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "domain-browser": "1.1.7",
-        "events": "1.1.1",
-        "https-browserify": "1.0.0",
-        "os-browserify": "0.3.0",
-        "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.3",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.7.2",
-        "string_decoder": "1.0.3",
-        "timers-browserify": "2.0.4",
-        "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.3",
-        "vm-browserify": "0.0.4"
-      },
-      "dependencies": {
-        "process": {
-          "version": "0.11.10",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
-    },
     "nodeify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/nodeify/-/nodeify-1.0.1.tgz",
@@ -7851,18 +8105,9 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
       "requires": {
         "remove-trailing-separator": "1.1.0"
-      }
-    },
-    "normalize-space-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-3.0.0.tgz",
-      "integrity": "sha512-tbCJerqZCCHPst4rRKgsTanLf45fjOyeAU5zE3mhDxJtFJKt66q39g2XArWhXelgTFVib8mNBUm6Wrd0LxYcfQ==",
-      "requires": {
-        "cached-constructors-x": "1.0.0",
-        "trim-x": "3.0.0",
-        "white-space-x": "3.0.0"
       }
     },
     "normalize-url": {
@@ -7921,23 +8166,6 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
-    "object-get-own-property-descriptor-x": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/object-get-own-property-descriptor-x/-/object-get-own-property-descriptor-x-3.2.0.tgz",
-      "integrity": "sha512-Z/0fIrptD9YuzN+SNK/1kxAEaBcPQM4gSrtOSMSi9eplnL/AbyQcAyAlreAoAzmBon+DQ1Z+AdhxyQSvav5Fyg==",
-      "requires": {
-        "attempt-x": "1.1.1",
-        "has-own-property-x": "3.2.0",
-        "has-symbol-support-x": "1.4.1",
-        "is-falsey-x": "1.0.1",
-        "is-index-x": "1.1.0",
-        "is-primitive": "2.0.0",
-        "is-string": "1.0.4",
-        "property-is-enumerable-x": "1.1.0",
-        "to-object-x": "1.5.0",
-        "to-property-key-x": "2.0.2"
-      }
-    },
     "object-inspect": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.3.0.tgz",
@@ -7972,6 +8200,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "dev": true,
       "requires": {
         "for-own": "0.1.5",
         "is-extendable": "0.1.1"
@@ -8002,11 +8231,6 @@
           "dev": true
         }
       }
-    },
-    "on-build-webpack": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/on-build-webpack/-/on-build-webpack-0.1.0.tgz",
-      "integrity": "sha1-oofA4Xdm5hQZJuXyy7DYu1O3aBQ="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -8131,11 +8355,6 @@
         }
       }
     },
-    "os-browserify": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
-    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -8246,11 +8465,6 @@
         }
       }
     },
-    "pako": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
-    },
     "parse-asn1": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
@@ -8267,6 +8481,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "dev": true,
       "requires": {
         "glob-base": "0.3.0",
         "is-dotfile": "1.0.3",
@@ -8281,17 +8496,6 @@
       "requires": {
         "for-each": "0.3.2",
         "trim": "0.0.1"
-      }
-    },
-    "parse-int-x": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz",
-      "integrity": "sha512-NIMm52gmd1+0qxJK8lV3OZ4zzWpRH1xcz9xCHXl+DNzddwUdS4NEtd7BmTeK7iCIXoaK5e6BoDMHgieH2eNIhg==",
-      "requires": {
-        "cached-constructors-x": "1.0.0",
-        "nan-x": "1.0.0",
-        "to-string-x": "1.4.2",
-        "trim-left-x": "3.0.0"
       }
     },
     "parse-json": {
@@ -8312,11 +8516,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
-    },
-    "path-browserify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
     },
     "path-exists": {
       "version": "3.0.0",
@@ -8573,7 +8772,8 @@
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
     },
     "pretty-ms": {
       "version": "2.1.0",
@@ -8623,19 +8823,19 @@
         "is-promise": "1.0.1"
       }
     },
+    "promise-to-callback": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
+      "integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc=",
+      "requires": {
+        "is-fn": "1.0.0",
+        "set-immediate-shim": "1.0.1"
+      }
+    },
     "promisify-es6": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/promisify-es6/-/promisify-es6-1.0.3.tgz",
       "integrity": "sha512-N9iVG+CGJsI4b4ZGazjwLnxErD2d9Pe4DPvvXSxYA9tFNu8ymXME4Qs5HIQ0LMJpNM7zj+m0NlNnNeqFpKzqnA=="
-    },
-    "property-is-enumerable-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/property-is-enumerable-x/-/property-is-enumerable-x-1.1.0.tgz",
-      "integrity": "sha512-22cKy3w3OpRswU6to9iKWDDlg+F9vF2REcwGlGW23jyLjHb1U/jJEWA44sWupOnkhGfDgotU6Lw+N2oyhNi+5A==",
-      "requires": {
-        "to-object-x": "1.5.0",
-        "to-property-key-x": "2.0.2"
-      }
     },
     "protocol-buffers-schema": {
       "version": "3.3.2",
@@ -8695,14 +8895,14 @@
       "integrity": "sha1-CIew/7MK8ypW2+z6csFnInHwexM="
     },
     "pull-level": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.3.tgz",
-      "integrity": "sha1-lQBjXiV5Rdb+7eGF9deiR3NFWxc=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
+      "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
       "requires": {
-        "level-post": "1.0.5",
+        "level-post": "1.0.7",
         "pull-cat": "1.1.11",
         "pull-live": "1.0.1",
-        "pull-pushable": "2.1.1",
+        "pull-pushable": "2.2.0",
         "pull-stream": "3.6.1",
         "pull-window": "2.1.4",
         "stream-to-pull-stream": "1.7.2"
@@ -8718,9 +8918,9 @@
       }
     },
     "pull-pushable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.1.1.tgz",
-      "integrity": "sha1-hmZqu+P1QC8ffq0D7v1pt4Xspbg="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
+      "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE="
     },
     "pull-stream": {
       "version": "3.6.1",
@@ -8741,9 +8941,9 @@
       }
     },
     "pump": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
       "requires": {
         "end-of-stream": "1.4.0",
         "once": "1.4.0"
@@ -8769,20 +8969,11 @@
         "strict-uri-encode": "1.1.0"
       }
     },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
-    },
-    "querystring-es3": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
-    },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "dev": true,
       "requires": {
         "is-number": "3.0.0",
         "kind-of": "4.0.0"
@@ -8792,6 +8983,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
           "requires": {
             "kind-of": "3.2.2"
           },
@@ -8800,6 +8992,7 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
               "requires": {
                 "is-buffer": "1.1.6"
               }
@@ -8810,6 +9003,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
           "requires": {
             "is-buffer": "1.1.6"
           }
@@ -8945,6 +9139,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "minimatch": "3.0.4",
@@ -9017,6 +9212,7 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "dev": true,
       "requires": {
         "is-equal-shallow": "0.1.3"
       }
@@ -9075,17 +9271,20 @@
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
     },
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "repeating": {
       "version": "2.0.1",
@@ -9093,15 +9292,6 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
         "is-finite": "1.0.2"
-      }
-    },
-    "replace-comments-x": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/replace-comments-x/-/replace-comments-x-2.0.0.tgz",
-      "integrity": "sha512-+vMP4jqU+8HboLWms6YMNEiaZG5hh1oR6ENCnGYDF/UQ7aYiJUK/8tcl3+KZAHRCKKa3gqzrfiarlUBHQSgRlg==",
-      "requires": {
-        "require-coercible-to-string-x": "1.0.0",
-        "to-string-x": "1.4.2"
       }
     },
     "request": {
@@ -9140,15 +9330,6 @@
         }
       }
     },
-    "require-coercible-to-string-x": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/require-coercible-to-string-x/-/require-coercible-to-string-x-1.0.0.tgz",
-      "integrity": "sha512-Rpfd4sMdflPAKecdKhfAtQHlZzzle4UMUgxJ01hXtTcNWMV8w9GeZnKhEyrT73kgrflBOP1zg41amUPZGcNspA==",
-      "requires": {
-        "require-object-coercible-x": "1.4.1",
-        "to-string-x": "1.4.2"
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -9163,14 +9344,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-    },
-    "require-object-coercible-x": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/require-object-coercible-x/-/require-object-coercible-x-1.4.1.tgz",
-      "integrity": "sha512-0YHa2afepsLfQvwQ1P2XvDZnGOUia5sC07ZijIRU2dnsRxnuilXWF6B2CFaKGDA9eZl39lJHrXCDsnfgroRd6Q==",
-      "requires": {
-        "is-nil-x": "1.4.1"
-      }
     },
     "require-precompiled": {
       "version": "0.1.0",
@@ -9243,14 +9416,6 @@
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "requires": {
         "through": "2.3.8"
-      }
-    },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "requires": {
-        "align-text": "0.1.4"
       }
     },
     "rimraf": {
@@ -9344,6 +9509,11 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "sandwich-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/sandwich-stream/-/sandwich-stream-1.0.0.tgz",
+      "integrity": "sha1-eDDkV5e1kzKH8fmyj4cZB0ViYvI="
     },
     "scrypt": {
       "version": "6.0.3",
@@ -9663,11 +9833,6 @@
         "is-plain-obj": "1.1.0"
       }
     },
-    "source-list-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-      "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
-    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -9786,15 +9951,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
-    },
-    "stream-browserify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
-      "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
-      }
     },
     "stream-http": {
       "version": "2.7.2",
@@ -10084,11 +10240,6 @@
         }
       }
     },
-    "tapable": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
-      "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
-    },
     "tape": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
@@ -10347,14 +10498,6 @@
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
-    "timers-browserify": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
-      "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
-      "requires": {
-        "setimmediate": "1.0.5"
-      }
-    },
     "tiny-queue": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/tiny-queue/-/tiny-queue-0.2.0.tgz",
@@ -10392,99 +10535,10 @@
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
     },
-    "to-boolean-x": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.1.tgz",
-      "integrity": "sha512-PstxY3K6hVEHnY3FITs8XBoJbt0RI1e4MLIhAL9hWa3BtVLCrb86vU5z6lEKh7uZZjiPiLqIKMmfMro1nNgtXQ=="
-    },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
-    },
-    "to-integer-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz",
-      "integrity": "sha512-794L2Lpwjtynm7RxahJi2YdbRY75gTxUW27TMuN26UgwPkmJb/+HPhkFEFbz+E4vNoiP0dxq5tq5fkXoXLaK/w==",
-      "requires": {
-        "is-finite-x": "3.0.2",
-        "is-nan-x": "1.0.1",
-        "math-sign-x": "3.0.0",
-        "to-number-x": "2.0.0"
-      }
-    },
-    "to-number-x": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz",
-      "integrity": "sha512-lGOnCoccUoSzjZ/9Uen8TC4+VFaQcFGhTroWTv2tYWxXgyJV1zqAZ8hEIMkez/Eo790fBMOjidTnQ/OJSCvAoQ==",
-      "requires": {
-        "cached-constructors-x": "1.0.0",
-        "nan-x": "1.0.0",
-        "parse-int-x": "2.0.0",
-        "to-primitive-x": "1.1.0",
-        "trim-x": "3.0.0"
-      }
-    },
-    "to-object-x": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/to-object-x/-/to-object-x-1.5.0.tgz",
-      "integrity": "sha512-AKn5GQcdWky+s20vjWkt+Wa6y3dxQH3yQyMBhOfBOPldUwqwhgvlqcIg5H092ntNc+TX8/Cxzs1kMHH19pyCnA==",
-      "requires": {
-        "cached-constructors-x": "1.0.0",
-        "require-object-coercible-x": "1.4.1"
-      }
-    },
-    "to-primitive-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/to-primitive-x/-/to-primitive-x-1.1.0.tgz",
-      "integrity": "sha512-gyMY0gi3wjK3e4MUBKqv9Zl8QGcWguIkaUr2VJmoBEsOpDcpDZSEyljR773eVG4maS48uX7muLkoQoh/BA82OQ==",
-      "requires": {
-        "has-symbol-support-x": "1.4.1",
-        "is-date-object": "1.0.1",
-        "is-function-x": "3.3.0",
-        "is-nil-x": "1.4.1",
-        "is-primitive": "2.0.0",
-        "is-symbol": "1.0.1",
-        "require-object-coercible-x": "1.4.1",
-        "validate.io-undefined": "1.0.3"
-      }
-    },
-    "to-property-key-x": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/to-property-key-x/-/to-property-key-x-2.0.2.tgz",
-      "integrity": "sha512-YISLpZFYIazNm0P8hLsKEEUEZ3m8U3+eDysJZqTu3+B9tQp+2TrMpaEGT8Agh4fZ5LSoums60/glNEzk5ozqrg==",
-      "requires": {
-        "has-symbol-support-x": "1.4.1",
-        "to-primitive-x": "1.1.0",
-        "to-string-x": "1.4.2"
-      }
-    },
-    "to-string-symbols-supported-x": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-string-symbols-supported-x/-/to-string-symbols-supported-x-1.0.0.tgz",
-      "integrity": "sha512-HbVH673pybrUmhzESGHUm17BBJvqb7BU8HciOvuEYm9ipuDyjmddhvkVqpVW6sM/C5/zhJo17n7O7I/24loJIQ==",
-      "requires": {
-        "cached-constructors-x": "1.0.0",
-        "has-symbol-support-x": "1.4.1",
-        "is-symbol": "1.0.1"
-      }
-    },
-    "to-string-tag-x": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/to-string-tag-x/-/to-string-tag-x-1.4.2.tgz",
-      "integrity": "sha512-ytO9eLigxsQQLGuab0C1iSSTzKdJNVSlBg0Spg4J/rGAVrQJ5y774mo0SSzgGeTT4RJGGyJNfObXaTMzX0XDOQ==",
-      "requires": {
-        "lodash.isnull": "3.0.0",
-        "validate.io-undefined": "1.0.3"
-      }
-    },
-    "to-string-x": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/to-string-x/-/to-string-x-1.4.2.tgz",
-      "integrity": "sha512-/WP5arlwtCpAAexCCHiQBW0eXwse84osWyP1Qtaz71nsYSuUpOkT6tBm8nQ4IIUfSh5hji0hDupUCD2xbbOL6A==",
-      "requires": {
-        "is-symbol": "1.0.1"
-      }
     },
     "tough-cookie": {
       "version": "2.3.3",
@@ -10506,16 +10560,6 @@
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
-    "trim-left-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-3.0.0.tgz",
-      "integrity": "sha512-+m6cqkppI+CxQBTwWEZliOHpOBnCArGyMnS1WCLb6IRgukhTkiQu/TNEN5Lj2eM9jk8ewJsc7WxFZfmwNpRXWQ==",
-      "requires": {
-        "cached-constructors-x": "1.0.0",
-        "require-coercible-to-string-x": "1.0.0",
-        "white-space-x": "3.0.0"
-      }
-    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -10532,25 +10576,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
-    },
-    "trim-right-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-3.0.0.tgz",
-      "integrity": "sha512-iIqEsWEbWVodqdixJHi4FoayJkUxhoL4AvSNGp4FF4FfQKRPGizt8++/RnyC9od75y7P/S6EfONoVqP+NddiKA==",
-      "requires": {
-        "cached-constructors-x": "1.0.0",
-        "require-coercible-to-string-x": "1.0.0",
-        "white-space-x": "3.0.0"
-      }
-    },
-    "trim-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-3.0.0.tgz",
-      "integrity": "sha512-w8s38RAUScQ6t3XqMkS75iz5ZkIYLQpVnv2lp3IuTS36JdlVzC54oe6okOf4Wz3UH4rr3XAb2xR3kR5Xei82fw==",
-      "requires": {
-        "trim-left-x": "3.0.0",
-        "trim-right-x": "3.0.0"
-      }
     },
     "truffle-privatekey-provider": {
       "version": "0.0.5",
@@ -10624,11 +10649,6 @@
         }
       }
     },
-    "tty-browserify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-      "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
-    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -10687,9 +10707,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typedarray-to-buffer": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.2.tgz",
-      "integrity": "sha1-EBezLZhP9VbroQD1AViauhrOLgQ=",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "requires": {
         "is-typedarray": "1.0.0"
       }
@@ -10711,55 +10731,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
       "integrity": "sha1-yIgvobsQksBgBal/NO9chQjjZk4="
-    },
-    "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
-            "wordwrap": "0.0.2"
-          }
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
-          }
-        }
-      }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "optional": true
     },
     "uid2": {
       "version": "0.0.3",
@@ -10866,22 +10837,6 @@
         "xdg-basedir": "3.0.0"
       }
     },
-    "url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-        }
-      }
-    },
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -10914,21 +10869,6 @@
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
       "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
     },
-    "util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-      "requires": {
-        "inherits": "2.0.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-        }
-      }
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -10953,11 +10893,6 @@
         "spdx-expression-parse": "1.0.4"
       }
     },
-    "validate.io-undefined": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/validate.io-undefined/-/validate.io-undefined-1.0.3.tgz",
-      "integrity": "sha1-fif8uzFbhB54JDQxiXZxkp4gt/Q="
-    },
     "varint": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
@@ -10978,52 +10913,24 @@
         "extsprintf": "1.3.0"
       }
     },
-    "vm-browserify": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-      "requires": {
-        "indexof": "0.0.1"
-      }
-    },
-    "watchpack": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
-      "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
-      "requires": {
-        "async": "2.6.0",
-        "chokidar": "1.7.0",
-        "graceful-fs": "4.1.11"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        }
-      }
-    },
     "web3": {
       "version": "1.0.0-beta.26",
       "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.26.tgz",
       "integrity": "sha1-u0ba9q78MT92iz3jnX9KjXvQZmM=",
       "requires": {
-        "web3-bzz": "1.0.0-beta.31",
-        "web3-core": "1.0.0-beta.31",
-        "web3-eth": "1.0.0-beta.31",
-        "web3-eth-personal": "1.0.0-beta.31",
-        "web3-net": "1.0.0-beta.31",
-        "web3-shh": "1.0.0-beta.31",
-        "web3-utils": "1.0.0-beta.31"
+        "web3-bzz": "1.0.0-beta.33",
+        "web3-core": "1.0.0-beta.33",
+        "web3-eth": "1.0.0-beta.33",
+        "web3-eth-personal": "1.0.0-beta.33",
+        "web3-net": "1.0.0-beta.33",
+        "web3-shh": "1.0.0-beta.33",
+        "web3-utils": "1.0.0-beta.33"
       }
     },
     "web3-bzz": {
-      "version": "1.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.31.tgz",
-      "integrity": "sha1-rrp8lVhhqZupLdHKj3x6EngyhZ0=",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.33.tgz",
+      "integrity": "sha1-MVAPaZt+cO31FJDFXv+0J7+7OwE=",
       "requires": {
         "got": "7.1.0",
         "swarm-js": "0.1.37",
@@ -11031,97 +10938,97 @@
       }
     },
     "web3-core": {
-      "version": "1.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.31.tgz",
-      "integrity": "sha1-q9FJzEEshTZb9NEZfHSeP1Dj6qE=",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.33.tgz",
+      "integrity": "sha1-+C7VJfW2auzale7O08rSvWlfeDk=",
       "requires": {
-        "web3-core-helpers": "1.0.0-beta.31",
-        "web3-core-method": "1.0.0-beta.31",
-        "web3-core-requestmanager": "1.0.0-beta.31",
-        "web3-utils": "1.0.0-beta.31"
+        "web3-core-helpers": "1.0.0-beta.33",
+        "web3-core-method": "1.0.0-beta.33",
+        "web3-core-requestmanager": "1.0.0-beta.33",
+        "web3-utils": "1.0.0-beta.33"
       }
     },
     "web3-core-helpers": {
-      "version": "1.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.31.tgz",
-      "integrity": "sha1-cETI89P3NRWLoeZrhPbECQiCFlw=",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.33.tgz",
+      "integrity": "sha1-Kvcz5QTbBefDZIwdrPV3sOwV3EM=",
       "requires": {
         "underscore": "1.8.3",
-        "web3-eth-iban": "1.0.0-beta.31",
-        "web3-utils": "1.0.0-beta.31"
+        "web3-eth-iban": "1.0.0-beta.33",
+        "web3-utils": "1.0.0-beta.33"
       }
     },
     "web3-core-method": {
-      "version": "1.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.31.tgz",
-      "integrity": "sha1-IRkLm4zxUDUT6Diw9O73Jg/uCTs=",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.33.tgz",
+      "integrity": "sha1-7Y7ExK+rIdwJid41g2hEZlIrboY=",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.31",
-        "web3-core-promievent": "1.0.0-beta.31",
-        "web3-core-subscriptions": "1.0.0-beta.31",
-        "web3-utils": "1.0.0-beta.31"
+        "web3-core-helpers": "1.0.0-beta.33",
+        "web3-core-promievent": "1.0.0-beta.33",
+        "web3-core-subscriptions": "1.0.0-beta.33",
+        "web3-utils": "1.0.0-beta.33"
       }
     },
     "web3-core-promievent": {
-      "version": "1.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.31.tgz",
-      "integrity": "sha1-3alb5l7NeSTjAKXphHfBuwpX6PM=",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.33.tgz",
+      "integrity": "sha1-0fXrtgFSfdSWViw2IXblWNly01g=",
       "requires": {
         "any-promise": "1.3.0",
         "eventemitter3": "1.1.1"
       }
     },
     "web3-core-requestmanager": {
-      "version": "1.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.31.tgz",
-      "integrity": "sha1-S/ZntBTUbgZtmTCZTzT0b7QI++c=",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.33.tgz",
+      "integrity": "sha1-ejbEA1QALfsXnKLb22pgEsn3Ges=",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.31",
-        "web3-providers-http": "1.0.0-beta.31",
-        "web3-providers-ipc": "1.0.0-beta.31",
-        "web3-providers-ws": "1.0.0-beta.31"
+        "web3-core-helpers": "1.0.0-beta.33",
+        "web3-providers-http": "1.0.0-beta.33",
+        "web3-providers-ipc": "1.0.0-beta.33",
+        "web3-providers-ws": "1.0.0-beta.33"
       }
     },
     "web3-core-subscriptions": {
-      "version": "1.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.31.tgz",
-      "integrity": "sha1-fpAG3iCosEB6wTZO9WuHz8TQ8ks=",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.33.tgz",
+      "integrity": "sha1-YCh1yfTV9NDhYhRitfwewZs1veM=",
       "requires": {
         "eventemitter3": "1.1.1",
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.31"
+        "web3-core-helpers": "1.0.0-beta.33"
       }
     },
     "web3-eth": {
-      "version": "1.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.31.tgz",
-      "integrity": "sha1-t7SwdVNLOjsKtbVpe9UIXXnrYcY=",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.33.tgz",
+      "integrity": "sha1-hKn5TallUnyS2DitTlcN8CWJhJ8=",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.31",
-        "web3-core-helpers": "1.0.0-beta.31",
-        "web3-core-method": "1.0.0-beta.31",
-        "web3-core-subscriptions": "1.0.0-beta.31",
-        "web3-eth-abi": "1.0.0-beta.31",
-        "web3-eth-accounts": "1.0.0-beta.31",
-        "web3-eth-contract": "1.0.0-beta.31",
-        "web3-eth-iban": "1.0.0-beta.31",
-        "web3-eth-personal": "1.0.0-beta.31",
-        "web3-net": "1.0.0-beta.31",
-        "web3-utils": "1.0.0-beta.31"
+        "web3-core": "1.0.0-beta.33",
+        "web3-core-helpers": "1.0.0-beta.33",
+        "web3-core-method": "1.0.0-beta.33",
+        "web3-core-subscriptions": "1.0.0-beta.33",
+        "web3-eth-abi": "1.0.0-beta.33",
+        "web3-eth-accounts": "1.0.0-beta.33",
+        "web3-eth-contract": "1.0.0-beta.33",
+        "web3-eth-iban": "1.0.0-beta.33",
+        "web3-eth-personal": "1.0.0-beta.33",
+        "web3-net": "1.0.0-beta.33",
+        "web3-utils": "1.0.0-beta.33"
       }
     },
     "web3-eth-abi": {
-      "version": "1.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.31.tgz",
-      "integrity": "sha1-xQ457cINFrTDWQKegpuEE5THL8E=",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.33.tgz",
+      "integrity": "sha1-IiH3FRZDZgAypN80D2EjSRaMgko=",
       "requires": {
         "bn.js": "4.11.6",
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.31",
-        "web3-utils": "1.0.0-beta.31"
+        "web3-core-helpers": "1.0.0-beta.33",
+        "web3-utils": "1.0.0-beta.33"
       },
       "dependencies": {
         "bn.js": {
@@ -11132,9 +11039,9 @@
       }
     },
     "web3-eth-accounts": {
-      "version": "1.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.31.tgz",
-      "integrity": "sha1-Mnm9BpbYK8ThUswddWx74i0xkq0=",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.33.tgz",
+      "integrity": "sha1-JajX9OWOHpk7kvBpVILMzckhL5E=",
       "requires": {
         "any-promise": "1.3.0",
         "crypto-browserify": "3.12.0",
@@ -11142,10 +11049,10 @@
         "scrypt.js": "0.2.0",
         "underscore": "1.8.3",
         "uuid": "2.0.1",
-        "web3-core": "1.0.0-beta.31",
-        "web3-core-helpers": "1.0.0-beta.31",
-        "web3-core-method": "1.0.0-beta.31",
-        "web3-utils": "1.0.0-beta.31"
+        "web3-core": "1.0.0-beta.33",
+        "web3-core-helpers": "1.0.0-beta.33",
+        "web3-core-method": "1.0.0-beta.33",
+        "web3-utils": "1.0.0-beta.33"
       },
       "dependencies": {
         "eth-lib": {
@@ -11166,68 +11073,80 @@
       }
     },
     "web3-eth-contract": {
-      "version": "1.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.31.tgz",
-      "integrity": "sha1-J5RkM/kdiVMBPi2X/Yt4qe1rbtw=",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.33.tgz",
+      "integrity": "sha1-nlkZ8pF6PGe0+2Vp1JxeMDiSW84=",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.31",
-        "web3-core-helpers": "1.0.0-beta.31",
-        "web3-core-method": "1.0.0-beta.31",
-        "web3-core-promievent": "1.0.0-beta.31",
-        "web3-core-subscriptions": "1.0.0-beta.31",
-        "web3-eth-abi": "1.0.0-beta.31",
-        "web3-utils": "1.0.0-beta.31"
+        "web3-core": "1.0.0-beta.33",
+        "web3-core-helpers": "1.0.0-beta.33",
+        "web3-core-method": "1.0.0-beta.33",
+        "web3-core-promievent": "1.0.0-beta.33",
+        "web3-core-subscriptions": "1.0.0-beta.33",
+        "web3-eth-abi": "1.0.0-beta.33",
+        "web3-utils": "1.0.0-beta.33"
       }
     },
     "web3-eth-iban": {
-      "version": "1.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.31.tgz",
-      "integrity": "sha1-7WS+0zO7BApvKU+06dGOrdvr/8o=",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.33.tgz",
+      "integrity": "sha1-HXPQxSiKRWWxdUp1tfs+oLd6Uy8=",
       "requires": {
-        "bn.js": "4.11.8",
-        "web3-utils": "1.0.0-beta.31"
+        "bn.js": "4.11.6",
+        "web3-utils": "1.0.0-beta.33"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+        }
       }
     },
     "web3-eth-personal": {
-      "version": "1.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.31.tgz",
-      "integrity": "sha1-Kw1ghZIOndzfu63yCnFfDMN3HYA=",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.33.tgz",
+      "integrity": "sha1-tOSFh8xOfrAY2ib947Tzul+bmO8=",
       "requires": {
-        "web3-core": "1.0.0-beta.31",
-        "web3-core-helpers": "1.0.0-beta.31",
-        "web3-core-method": "1.0.0-beta.31",
-        "web3-net": "1.0.0-beta.31",
-        "web3-utils": "1.0.0-beta.31"
+        "web3-core": "1.0.0-beta.33",
+        "web3-core-helpers": "1.0.0-beta.33",
+        "web3-core-method": "1.0.0-beta.33",
+        "web3-net": "1.0.0-beta.33",
+        "web3-utils": "1.0.0-beta.33"
       }
     },
     "web3-net": {
-      "version": "1.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.31.tgz",
-      "integrity": "sha1-0mv8oOoXUvX9XXITTgDlE60efhk=",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.33.tgz",
+      "integrity": "sha1-tskNGg4WJuquiz2SKsFTZy/VZEU=",
       "requires": {
-        "web3-core": "1.0.0-beta.31",
-        "web3-core-method": "1.0.0-beta.31",
-        "web3-utils": "1.0.0-beta.31"
+        "web3-core": "1.0.0-beta.33",
+        "web3-core-method": "1.0.0-beta.33",
+        "web3-utils": "1.0.0-beta.33"
       }
     },
     "web3-provider-engine": {
-      "version": "8.1.19",
-      "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-8.1.19.tgz",
-      "integrity": "sha1-PMrpWt7O9VYy4qc7877mS35i/Pc=",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-13.6.6.tgz",
+      "integrity": "sha512-M9eztIxwCR2U7+d42RXdu3fBjvG/kcv7Ra8z2PHs912aHhAkMtNfvzhC8dboC7yKmj230eVHwouSXKizmSqC7Q==",
       "requires": {
         "async": "2.6.0",
         "clone": "2.1.1",
+        "eth-block-tracker": "2.3.0",
+        "eth-sig-util": "1.4.2",
         "ethereumjs-block": "1.2.2",
         "ethereumjs-tx": "1.3.3",
         "ethereumjs-util": "5.1.2",
         "ethereumjs-vm": "2.3.2",
-        "isomorphic-fetch": "2.2.1",
+        "fetch-ponyfill": "4.1.0",
+        "json-rpc-error": "2.0.0",
+        "json-stable-stringify": "1.0.1",
+        "promise-to-callback": "1.0.0",
+        "readable-stream": "2.3.3",
         "request": "2.83.0",
         "semaphore": "1.1.0",
         "solc": "0.4.18",
         "tape": "4.8.0",
-        "web3": "0.16.0",
         "xhr": "2.4.1",
         "xtend": "4.0.1"
       },
@@ -11239,49 +11158,35 @@
           "requires": {
             "lodash": "4.17.4"
           }
-        },
-        "bignumber.js": {
-          "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
-        },
-        "web3": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
-          "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
-          "requires": {
-            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-            "crypto-js": "3.1.8",
-            "utf8": "2.1.2",
-            "xmlhttprequest": "1.8.0"
-          }
         }
       }
     },
     "web3-providers-http": {
-      "version": "1.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.31.tgz",
-      "integrity": "sha1-E0Ce9ErhYjzVxNzT20sI1vu6RTI=",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.33.tgz",
+      "integrity": "sha1-OzWuAO599blrSTSWKtSobypVmcE=",
       "requires": {
-        "web3-core-helpers": "1.0.0-beta.31",
+        "web3-core-helpers": "1.0.0-beta.33",
         "xhr2": "0.1.4"
       }
     },
     "web3-providers-ipc": {
-      "version": "1.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.31.tgz",
-      "integrity": "sha1-zm2mcPqhlFjmIt/tm+QAWE/DNyQ=",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.33.tgz",
+      "integrity": "sha1-Twrcmv6dEsBm5L5cPFNvUHPLB8Y=",
       "requires": {
         "oboe": "2.1.3",
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.31"
+        "web3-core-helpers": "1.0.0-beta.33"
       }
     },
     "web3-providers-ws": {
-      "version": "1.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.31.tgz",
-      "integrity": "sha1-zHG3Do2LUyAaUzdDcHww6MCZ4o0=",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.33.tgz",
+      "integrity": "sha1-j93qQuGbvyUh7IeVRkV6Yjqdye8=",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.31",
+        "web3-core-helpers": "1.0.0-beta.33",
         "websocket": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c"
       },
       "dependencies": {
@@ -11290,27 +11195,27 @@
           "requires": {
             "debug": "2.6.9",
             "nan": "2.8.0",
-            "typedarray-to-buffer": "3.1.2",
+            "typedarray-to-buffer": "3.1.5",
             "yaeti": "0.0.6"
           }
         }
       }
     },
     "web3-shh": {
-      "version": "1.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.31.tgz",
-      "integrity": "sha1-AW0gS+K7obfzs5FQJyGdJ07+XlI=",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.33.tgz",
+      "integrity": "sha1-+Z4mVz9uCZMhrw2fK/z+Pe01UKE=",
       "requires": {
-        "web3-core": "1.0.0-beta.31",
-        "web3-core-method": "1.0.0-beta.31",
-        "web3-core-subscriptions": "1.0.0-beta.31",
-        "web3-net": "1.0.0-beta.31"
+        "web3-core": "1.0.0-beta.33",
+        "web3-core-method": "1.0.0-beta.33",
+        "web3-core-subscriptions": "1.0.0-beta.33",
+        "web3-net": "1.0.0-beta.33"
       }
     },
     "web3-utils": {
-      "version": "1.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.31.tgz",
-      "integrity": "sha1-DxgSXT6WmK6Cy/b6Ka3B4WFvKTY=",
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
+      "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
       "requires": {
         "bn.js": "4.11.6",
         "eth-lib": "0.1.27",
@@ -11333,111 +11238,13 @@
         }
       }
     },
-    "webcrypto-shim": {
-      "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
-    },
-    "webpack": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.7.0.tgz",
-      "integrity": "sha512-MjAA0ZqO1ba7ZQJRnoCdbM56mmFpipOPUv/vQpwwfSI42p5PVDdoiuK2AL2FwFUVgT859Jr43bFZXRg/LNsqvg==",
+    "websocket": {
+      "version": "git://github.com/frozeman/WebSocket-Node.git#7004c39c42ac98875ab61126e5b4a925430f592c",
       "requires": {
-        "acorn": "5.2.1",
-        "acorn-dynamic-import": "2.0.2",
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "async": "2.6.0",
-        "enhanced-resolve": "3.4.1",
-        "interpret": "1.1.0",
-        "json-loader": "0.5.7",
-        "json5": "0.5.1",
-        "loader-runner": "2.3.0",
-        "loader-utils": "0.2.17",
-        "memory-fs": "0.4.1",
-        "mkdirp": "0.5.1",
-        "node-libs-browser": "2.1.0",
-        "source-map": "0.5.7",
-        "supports-color": "3.2.3",
-        "tapable": "0.2.8",
-        "uglify-js": "2.8.29",
-        "watchpack": "1.4.0",
-        "webpack-sources": "1.1.0",
-        "yargs": "6.6.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "async": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "requires": {
-            "has-flag": "1.0.0"
-          }
-        },
-        "yargs": {
-          "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-          "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "4.2.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-          "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-          "requires": {
-            "camelcase": "3.0.0"
-          }
-        }
-      }
-    },
-    "webpack-sources": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
-      "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
-      "requires": {
-        "source-list-map": "2.0.0",
-        "source-map": "0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
+        "debug": "2.6.9",
+        "nan": "2.8.0",
+        "typedarray-to-buffer": "3.1.5",
+        "yaeti": "0.0.6"
       }
     },
     "well-known-symbols": {
@@ -11447,9 +11254,9 @@
       "dev": true
     },
     "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "which": {
       "version": "1.3.0",
@@ -11463,11 +11270,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-    },
-    "white-space-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-3.0.0.tgz",
-      "integrity": "sha512-nMPVXGMdi/jQepXKryxqzEh/vCwdOYY/u6NZy40glMHvZfEr7/+vQKnDhEq4rZ1nniOFq9GWohQYB30uW/5Olg=="
     },
     "widest-line": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1488,6 +1488,9 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "bignumber.js": {
+      "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+    },
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
@@ -10594,9 +10597,6 @@
           "requires": {
             "lodash": "4.17.4"
           }
-        },
-        "bignumber.js": {
-          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
         },
         "web3": {
           "version": "0.20.6",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "figures": "^2.0.0",
     "find-up": "^2.1.0",
     "fs-extra": "^4.0.2",
-    "ganache-core": "~2.0.2",
+    "ganache-core": "^2.1.0",
     "git-clone": "^0.1.0",
     "homedir": "^0.6.0",
     "ignore": "^3.3.7",
@@ -48,7 +48,7 @@
     "listr": "^0.13.0",
     "semver": "^5.4.1",
     "tmp-promise": "^1.0.4",
-    "web3": "1.0.0-beta.26",
+    "web3": "^1.0.0-beta.26",
     "yargs": "^10.1.0"
   },
   "devDependencies": {

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -160,6 +160,7 @@ exports.handler = function (args) {
               ctx.contracts['APMRegistryFactory']
             )
 
+            // TODO: Create repo from appName repository
             return contract.methods.newAPM(
               namehash.hash('eth'),
               '0x' + keccak256('aragonpm'),
@@ -269,14 +270,16 @@ exports.handler = function (args) {
             })
           }
         },
-        // NOTE Temporary because permissions app does not exist
         {
           title: 'Set permissions',
           task: async (ctx, task) => {
-            const permissions = [
-              [ctx.accounts[0], ctx.appAddress, 'INCREMENT_ROLE'],
-              [ctx.accounts[0], ctx.appAddress, 'DECREMENT_ROLE']
-            ]
+            if (!module.roles || module.roles.length === 0) {
+              task.skip('No permissions defined in app')
+              return
+            }
+
+            const permissions = module.roles
+              .map((role) => [ctx.accounts[0], ctx.appAddress, role.id])
 
             return setPermissions(
               ctx.web3,

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -1,0 +1,202 @@
+const TaskList = require('listr')
+const ganache = require('ganache-core')
+const Web3 = require('web3')
+const namehash = require('eth-ens-namehash')
+const { keccak256 } = require('js-sha3')
+const chalk = require('chalk')
+
+const BLOCK_GAS_LIMIT = 50e6
+const TX_MIN_GAS = 10e6
+
+exports.command = 'run'
+
+exports.describe = 'Run the current app locally'
+
+exports.builder = {
+  port: {
+    description: 'The port to run the local chain on',
+    default: 8545
+  }
+}
+
+function getContract (pkg, contract) {
+  return require(`${pkg}/build/contracts/${contract}.json`)
+}
+
+function deployContract (web3, sender, { abi, bytecode }, args = []) {
+  const contract = new web3.eth.Contract(abi)
+
+  return contract.deploy({
+    data: bytecode,
+    arguments: args
+  }).send({
+    from: sender,
+    gas: TX_MIN_GAS
+  }).then((instance) => {
+    return instance.options.address
+  })
+}
+
+exports.handler = function ({ reporter, port }) {
+  const tasks = new TaskList([
+    {
+      title: 'Start local chain',
+      task: (ctx, task) => {
+        const server = ganache.server({
+          gasLimit: BLOCK_GAS_LIMIT
+        })
+
+        return new Promise((resolve, reject) => {
+          server.listen(port, (err) => {
+            if (err) return reject(err)
+
+            task.title = `Local chain started at :${port}`
+            resolve()
+          })
+        }).then(async () => {
+          // Set a temporary provider for deployments
+          ctx.web3 = new Web3(
+            new Web3.providers.WebsocketProvider(`ws://localhost:${port}`)
+          )
+
+          // Grab the accounts
+          ctx.accounts = await ctx.web3.eth.getAccounts()
+        })
+      }
+    },
+    {
+      title: 'Deploy APM and ENS',
+      task: (ctx, task) => new TaskList([
+        {
+          title: 'Deploy base contracts',
+          task: (ctx, task) => {
+            ctx.contracts = {}
+            const apmBaseContracts = [
+              ['@aragon/os', 'APMRegistry'],
+              ['@aragon/os', 'Repo'],
+              ['@aragon/os', 'ENSSubdomainRegistrar'],
+              ['@aragon/os', 'ENSFactory'],
+              ['@aragon/os', 'Kernel'],
+              ['@aragon/os', 'ACL']
+            ]
+              .map(([pkg, contractName]) => getContract(pkg, contractName))
+              .map((artifact) =>
+                deployContract(ctx.web3, ctx.accounts[0], artifact).then((contractAddress) => {
+                  task.title = `Deployed ${artifact.contractName} to ${contractAddress}`
+
+                  ctx.contracts[artifact.contractName] = contractAddress
+                })
+              )
+
+            return Promise.all(
+              apmBaseContracts
+            )
+          }
+        },
+        {
+          title: 'Deploy base DAO factory',
+          task: (ctx) => {
+            // 0x0 should be address to EVMScriptRegistryFactory
+            return deployContract(
+              ctx.web3, ctx.accounts[0], getContract('@aragon/os', 'DAOFactory'), [
+                ctx.contracts['Kernel'], ctx.contracts['ACL'], '0x0'
+              ]
+            ).then((daoFactoryAddress) => {
+              ctx.contracts['DAOFactory'] = daoFactoryAddress
+            })
+          }
+        },
+        {
+          title: 'Deploy APM registry factory',
+          task: (ctx, task) => {
+            return deployContract(
+              ctx.web3, ctx.accounts[0], getContract('@aragon/os', 'APMRegistryFactory'), [
+                ctx.contracts['DAOFactory'],
+                ctx.contracts['APMRegistry'],
+                ctx.contracts['Repo'],
+                ctx.contracts['ENSSubdomainRegistrar'],
+                '0x0',
+                ctx.contracts['ENSFactory']
+              ]
+            ).then((apmRegistryAddress) => {
+              ctx.contracts['APMRegistryFactory'] = apmRegistryAddress
+            })
+          }
+        },
+        {
+          title: 'Create APM registry',
+          task: (ctx) => {
+            const root = '0xffffffffffffffffffffffffffffffffffffffff'
+            const contract = new ctx.web3.eth.Contract(
+              getContract('@aragon/os', 'APMRegistryFactory').abi,
+              ctx.contracts['APMRegistryFactory']
+            )
+
+            return contract.methods.newAPM(
+              namehash.hash('eth'),
+              '0x' + keccak256('aragonpm'),
+              root
+            ).send({
+              from: ctx.accounts[0],
+              gas: TX_MIN_GAS
+            }).then(({ events }) => {
+              ctx.registryAddress = events['DeployAPM'].returnValues.apm
+
+              const registry = new ctx.web3.eth.Contract(
+                getContract('@aragon/os', 'APMRegistry').abi,
+                ctx.registryAddress
+              )
+              return registry.methods.registrar().call()
+            }).then((registrarAddress) => {
+              const registrar = new ctx.web3.eth.Contract(
+                getContract('@aragon/os', 'ENSSubdomainRegistrar').abi,
+                registrarAddress
+              )
+
+              return registrar.methods.ens().call()
+            }).then((ensAddress) => {
+              ctx.ensAddress = ensAddress
+            })
+          }
+        }
+      ])
+    },
+    {
+      title: 'Create DAO',
+      task: (ctx, task) => {
+        const factory = new ctx.web3.eth.Contract(
+          getContract('@aragon/os', 'DAOFactory').abi,
+          ctx.contracts['DAOFactory']
+        )
+
+        return factory.methods.newDAO(
+          ctx.accounts[0]
+        ).send({
+          from: ctx.accounts[0],
+          gas: TX_MIN_GAS
+        }).then(({ events }) => {
+          ctx.daoAddress = events['DeployDAO'].returnValues.dao
+        })
+      }
+    },
+    {
+      title: 'Starting APM HTTP provider',
+      task: (ctx, task) => {
+        task.title = 'Started APM HTTP provider on :1337'
+      }
+    }
+  ])
+
+  return tasks.run().then((ctx) => {
+    reporter.info(`You are now ready to open your app in Aragon.
+
+   This is the configuration for your development deployment:
+
+   ${chalk.bold('Ethereum Node')}: ws://localhost:${port}
+   ${chalk.bold('APM registry')}: ${ctx.registryAddress}
+   ${chalk.bold('ENS registry')}: ${ctx.ensAddress}
+   ${chalk.bold('DAO address')}: ${ctx.daoAddress}
+
+   Open up https://beta.aragon.com and enter this configuration in the settings!`)
+  })
+}


### PR DESCRIPTION
Requires #53 

The run command deploys all of the base contracts (APM, ENS, ...), creates a DAO and installs your local app in that DAO. It runs `ganache-core` as a chain you can interact with, and a modified version of `apm-serve` to serve files from the filesystem as an alternative APM provider to IPFS.

[A reviewer clicked this link and you won't believe what happened next](https://imgur.com/a/FNhuw)

**To do**

- Maybe (optionally) deploy base apps like voting and vault (`--with-base-apps`)
- Add `--skip-app` flag to only deploy a DAO, ENS and APM
- Autobuild project (if script is defined)
- Clean up a bit (extract some of the parts into other commands and run those serially)

**Temporary hacks**

- Starts a "correctly" configured wrapper and opens it up in a browser - this is a hack for now, since we have no way of configuring the wrapper without first downloading it and altering files

Closes #5 and #17 